### PR TITLE
Pod Affinity/Anti-Affinity symmetry feature

### DIFF
--- a/src/scheduling/flow/cost_model_interface.h
+++ b/src/scheduling/flow/cost_model_interface.h
@@ -162,6 +162,16 @@ class CostModelInterface {
   virtual vector<ResourceID_t>* GetTaskPreferenceArcs(TaskID_t task_id) = 0;
 
   /**
+   * Updates resource to task symmetry map.
+   */
+  virtual void UpdateResourceToTaskSymmetryMap(ResourceID_t res_id, TaskID_t td) {}
+
+  /**
+   * Removes task from resource to task symmetry map.
+   */
+  virtual void RemoveTaskFromTaskSymmetryMap(TaskDescriptor* td_ptr) {}
+
+  /**
    * Get equivalence classes to which the outgoing arcs of an equivalence class
    * are pointing to.
    * @return a vectors of equivalence classes to which we have an outgoing arc.

--- a/src/scheduling/flow/cost_model_interface.h
+++ b/src/scheduling/flow/cost_model_interface.h
@@ -172,6 +172,11 @@ class CostModelInterface {
   virtual void RemoveTaskFromTaskSymmetryMap(TaskDescriptor* td_ptr) {}
 
   /**
+   * Removes EC from EC to pod symmetry map.
+   */
+  virtual void RemoveECFromPodSymmetryMap(EquivClass_t ec) {}
+
+  /**
    * Get equivalence classes to which the outgoing arcs of an equivalence class
    * are pointing to.
    * @return a vectors of equivalence classes to which we have an outgoing arc.

--- a/src/scheduling/flow/cpu_cost_model.cc
+++ b/src/scheduling/flow/cpu_cost_model.cc
@@ -415,7 +415,7 @@ vector<EquivClass_t>* CpuCostModel::GetTaskEquivClasses(TaskID_t task_id) {
   CHECK_NOTNULL(task_resource_request);
   size_t task_agg = 0;
   bool pod_antiaffinity_symmetry = false;
-  if (td_ptr->has_affinity() || td_ptr->tolerations_size()) {
+  if (td_ptr->has_affinity() || (td_ptr->tolerations_size() > DEFAULT_TOLERATIONS)) {
     // For tasks which has affinity requirements, we hash the job id.
     // TODO(jagadish): This hash has to be handled in an efficient way in
     // future.

--- a/src/scheduling/flow/cpu_cost_model.h
+++ b/src/scheduling/flow/cpu_cost_model.h
@@ -147,7 +147,8 @@ class CpuCostModel : public CostModelInterface {
       const ResourceDescriptor& rd, const TaskDescriptor& td,
       const RepeatedPtrField<PodAffinityTerm>& podaffinityterms);
   bool SatisfiesPodAffinityAntiAffinityRequired(const ResourceDescriptor& rd,
-                                                const TaskDescriptor& td);
+                                                const TaskDescriptor& td,
+                                                const EquivClass_t ec);
   void CalculatePodAffinityAntiAffinityPreference(const ResourceDescriptor& rd,
                                                   const TaskDescriptor& td,
                                                   const EquivClass_t ec);
@@ -156,14 +157,42 @@ class CpuCostModel : public CostModelInterface {
                                                   const TaskDescriptor* td,
                                                   const EquivClass_t ec);
   // Pod affinity/anti-affinity symmetry
-  bool CheckPodAntiAffinitySymmetryConflict(TaskDescriptor* td_ptr);
+  bool CheckPodAffinityAntiAffinitySymmetryConflict(TaskDescriptor* td_ptr);
   void UpdateResourceToTaskSymmetryMap(ResourceID_t res_id, TaskID_t td);
   void RemoveTaskFromTaskSymmetryMap(TaskDescriptor* td_ptr);
-  bool SatisfiesSymmetryMatchExpression(unordered_multimap<string, string> task_labels, LabelSelectorRequirement expression_selector);
-  bool SatisfiesPodAntiAffinitySymmetryMatchExpressions(unordered_multimap<string, string> task_labels, const RepeatedPtrField<LabelSelectorRequirementAntiAff>& matchexpressions);
-  bool SatisfiesPodAntiAffinitySymmetryTerm(const TaskDescriptor& td, const TaskDescriptor& target_td, unordered_multimap<string, string> task_labels, const PodAffinityTermAntiAff podantiaffinityterm);
-  bool SatisfiesPodAntiAffinityTermsSymmetry(const TaskDescriptor& td, const TaskDescriptor& target_td, unordered_multimap<string, string> task_labels, const RepeatedPtrField<PodAffinityTermAntiAff>& podantiaffinityterms);
-  bool SatisfiesPodAntiAffinitySymmetry(ResourceID_t res_id, const TaskDescriptor& td);
+  void RemoveECFromPodSymmetryMap(EquivClass_t ec);
+  bool SatisfiesSymmetryMatchExpression(
+      unordered_multimap<string, string> task_labels,
+      LabelSelectorRequirement expression_selector);
+  bool SatisfiesPodAffinitySymmetryMatchExpressions(
+      unordered_multimap<string, string> task_labels,
+      const RepeatedPtrField<LabelSelectorRequirement>& matchexpressions);
+  bool SatisfiesPodAntiAffinitySymmetryMatchExpressions(
+      unordered_multimap<string, string> task_labels,
+      const RepeatedPtrField<LabelSelectorRequirementAntiAff>&
+          matchexpressions);
+  bool SatisfiesPodAffinitySymmetryTerm(
+      const TaskDescriptor& td, const TaskDescriptor& target_td,
+      unordered_multimap<string, string> task_labels,
+      const PodAffinityTerm& term);
+  bool SatisfiesPodAntiAffinitySymmetryTerm(
+      const TaskDescriptor& td, const TaskDescriptor& target_td,
+      unordered_multimap<string, string> task_labels,
+      const PodAffinityTermAntiAff podantiaffinityterm);
+  bool SatisfiesPodAntiAffinityTermsSymmetry(
+      const TaskDescriptor& td, const TaskDescriptor& target_td,
+      unordered_multimap<string, string> task_labels,
+      const RepeatedPtrField<PodAffinityTermAntiAff>& podantiaffinityterms);
+  bool SatisfiesPodAntiAffinitySymmetry(ResourceID_t res_id,
+                                        const TaskDescriptor& td);
+  int64_t CalculatePodAffinitySymmetryPreference(
+      Affinity affinity, const TaskDescriptor& td,
+      const TaskDescriptor& target_td,
+      unordered_multimap<string, string> task_labels);
+  int64_t CalculatePodAntiAffinitySymmetryPreference(
+      Affinity affinity, const TaskDescriptor& td,
+      const TaskDescriptor& target_td,
+      unordered_multimap<string, string> task_labels);
   vector<EquivClass_t>* GetEquivClassToEquivClassesArcs(EquivClass_t tec);
   void AddMachine(ResourceTopologyNodeDescriptor* rtnd_ptr);
   void AddTask(TaskID_t task_id);

--- a/src/scheduling/flow/cpu_cost_model.h
+++ b/src/scheduling/flow/cpu_cost_model.h
@@ -155,6 +155,15 @@ class CpuCostModel : public CostModelInterface {
   void CalculateIntolerableTaintsCost(const ResourceDescriptor& rd,
                                                   const TaskDescriptor* td,
                                                   const EquivClass_t ec);
+  // Pod affinity/anti-affinity symmetry
+  bool CheckPodAntiAffinitySymmetryConflict(TaskDescriptor* td_ptr);
+  void UpdateResourceToTaskSymmetryMap(ResourceID_t res_id, TaskID_t td);
+  void RemoveTaskFromTaskSymmetryMap(TaskDescriptor* td_ptr);
+  bool SatisfiesSymmetryMatchExpression(unordered_multimap<string, string> task_labels, LabelSelectorRequirement expression_selector);
+  bool SatisfiesPodAntiAffinitySymmetryMatchExpressions(unordered_multimap<string, string> task_labels, const RepeatedPtrField<LabelSelectorRequirementAntiAff>& matchexpressions);
+  bool SatisfiesPodAntiAffinitySymmetryTerm(const TaskDescriptor& td, const TaskDescriptor& target_td, unordered_multimap<string, string> task_labels, const PodAffinityTermAntiAff podantiaffinityterm);
+  bool SatisfiesPodAntiAffinityTermsSymmetry(const TaskDescriptor& td, const TaskDescriptor& target_td, unordered_multimap<string, string> task_labels, const RepeatedPtrField<PodAffinityTermAntiAff>& podantiaffinityterms);
+  bool SatisfiesPodAntiAffinitySymmetry(ResourceID_t res_id, const TaskDescriptor& td);
   vector<EquivClass_t>* GetEquivClassToEquivClassesArcs(EquivClass_t tec);
   void AddMachine(ResourceTopologyNodeDescriptor* rtnd_ptr);
   void AddTask(TaskID_t task_id);
@@ -223,6 +232,9 @@ class CpuCostModel : public CostModelInterface {
   // Pod affinity/anti-affinity
   unordered_map<string, unordered_map<string, vector<TaskID_t>>>* labels_map_;
   unordered_set<string> namespaces;
+  // Pod affinity/anti-affinity symmetry
+  unordered_map<ResourceID_t, vector<TaskID_t>, boost::hash<ResourceID_t>> resource_to_task_symmetry_map_;
+  unordered_set<EquivClass_t> ecs_with_pod_antiaffinity_symmetry_;
   unordered_map<EquivClass_t, ResourceID_t> ec_to_best_fit_resource_;
   unordered_map<EquivClass_t, Cost_t> ec_to_min_cost_;
   unordered_map<string, string> tolerationSoftEqualMap;

--- a/src/scheduling/flow/flow_graph_manager.cc
+++ b/src/scheduling/flow/flow_graph_manager.cc
@@ -498,6 +498,7 @@ void FlowGraphManager::RemoveEquivClassNode(FlowGraphNode* ec_node) {
   tec_to_node_map_.erase(ec_node->ec_id_);
   graph_change_manager_->DeleteNode(ec_node, DEL_EQUIV_CLASS_NODE,
                                     "RemoveEquivClassNode");
+  cost_model_->RemoveECFromPodSymmetryMap(ec_node->ec_id_);
 }
 
 void FlowGraphManager::RemoveInvalidECPrefArcs(


### PR DESCRIPTION
This feature addresses the issue with Pods which don't have a Pod Affinity/Anti-Affinity spec, but has labels that would result in conflicts with other Pods running on Node with Pod Affinity/Anti-Affinity.

Prior to this PR, this feature was not available in the firmament.