### PR TITLE
Fix for few crash cases

### DIFF
--- a/src/scheduling/event_driven_scheduler.cc
+++ b/src/scheduling/event_driven_scheduler.cc
@@ -514,7 +514,7 @@ void EventDrivenScheduler::KillRunningTask(
             << *rid << " (endpoint: " << td_ptr->last_heartbeat_location()
             << ")";
   m_adapter_ptr_->SendMessageToEndpoint(td_ptr->last_heartbeat_location(), bm);
-  if (!rid) {
+  if (rid) {
     CHECK(UnbindTaskFromResource(td_ptr, *rid));
   }
   trace_generator_->TaskKilled(task_id, rs_ptr->descriptor());

--- a/src/scheduling/firmament_scheduler_service.cc
+++ b/src/scheduling/firmament_scheduler_service.cc
@@ -434,6 +434,7 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
       label_sel_ptr->CopyFrom(label_selector);
     }
     // XXX(ionel): We may want to add support for other field updates as well.
+    reply->set_type(TaskReplyType::TASK_UPDATED_OK);
     return Status::OK;
   }
 

--- a/src/scheduling/flow/cpu_cost_model.cc
+++ b/src/scheduling/flow/cpu_cost_model.cc
@@ -1159,6 +1159,9 @@ void CpuCostModel::UpdateResourceToTaskSymmetryMap(ResourceID_t res_id,
 }
 
 void CpuCostModel::RemoveTaskFromTaskSymmetryMap(TaskDescriptor* td_ptr) {
+  if (td_ptr->scheduled_to_resource().empty()) {
+    return;
+  }
   ResourceID_t res_id = ResourceIDFromString(td_ptr->scheduled_to_resource());
   ResourceID_t machine_res_id = MachineResIDForResource(res_id);
   vector<TaskID_t>* tasks =

--- a/src/scheduling/flow/cpu_cost_model.cc
+++ b/src/scheduling/flow/cpu_cost_model.cc
@@ -573,7 +573,7 @@ void CpuCostModel::CalculateIntolerableTaintsCost(const ResourceDescriptor& rd,
                                }
 
                         }
-               else if (tolerations.operator_() == "Equal"){
+               else if ((tolerations.operator_() == "Equal") || (tolerations.operator_() == "")){
 
                                InsertIfNotPresent(&tolerationSoftEqualMap,tolerations.key(),tolerations.value());
 

--- a/src/scheduling/label_utils.cc
+++ b/src/scheduling/label_utils.cc
@@ -246,7 +246,7 @@ bool HasMatchingTolerationforNodeTaints(const ResourceDescriptor& rd,
           } else {
             IsTolerable = true;
           }
-        } else if (tolerations.operator_() == "Equal") {
+        } else if ((tolerations.operator_() == "Equal") || (tolerations.operator_() == "")) {
           if (tolerations.effect() != "") {
             InsertIfNotPresent(&tolerationHardEqualMap,
                                tolerations.key() + tolerations.effect(),


### PR DESCRIPTION
This PR addressed the following issues

1) The reply response to the gRPC call was not set prior to this change, this PR addresses that issue by setting the correct response to the TaskUpdate gRPC call.

2) Fixed a bug in remove task method, when a task is not scheduled and is called for deletion, the task removal was not done properly, this was causing a crash. This PR addresses that issue as well.

3) With the introduction of the simple solver for the pod affinity case, there were some issues/crashes, which are addressed in this PR.

4) For Toleration feature if no operator is specified then 'Equal' operator is assumed, this was missing prior to this fix, and is now addresed in this PR.