### PR TITLE
Placing mutex lock for Schedule service function

### DIFF
--- a/src/scheduling/firmament_scheduler_service.cc
+++ b/src/scheduling/firmament_scheduler_service.cc
@@ -161,6 +161,8 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
 
   Status Schedule(ServerContext* context, const ScheduleRequest* request,
                   SchedulingDeltas* reply) override {
+    boost::lock_guard<boost::recursive_mutex> lock(
+        scheduler_->scheduling_lock_);
     SchedulerStats sstat;
     vector<SchedulingDelta> deltas;
     scheduler_->ScheduleAllJobs(&sstat, &deltas);


### PR DESCRIPTION
Adding a lock to the ```Schedule gRPC method```, to guard against the task updates while a schedule call in under processing.