### PR TITLE
Adding events feature in Firmament

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -38,16 +38,16 @@ if (${ENABLE_PRIVATE_FLOWLESSLY})
       LOG_DOWNLOAD ON
       LOG_BUILD ON)
 else (${ENABLE_PRIVATE_FLOWLESSLY})
-  ExternalProject_Add(
-      flowlessly
-      GIT_REPOSITORY https://github.com/ICGog/Flowlessly.git
-      TIMEOUT 10
-      PREFIX ${CMAKE_CURRENT_BINARY_DIR}/third_party/flowlessly
+#  ExternalProject_Add(
+#      flowlessly
+#      GIT_REPOSITORY https://github.com/ICGog/Flowlessly.git
+#      TIMEOUT 10
+#      PREFIX ${CMAKE_CURRENT_BINARY_DIR}/third_party/flowlessly
       # no install required, we link the library from the build tree
-      INSTALL_COMMAND ""
+#      INSTALL_COMMAND ""
       # Wrap download, configure and build steps in a script to log output
-      LOG_DOWNLOAD ON
-      LOG_BUILD ON)
+#      LOG_DOWNLOAD ON
+#      LOG_BUILD ON)
 endif (${ENABLE_PRIVATE_FLOWLESSLY})
 
 ###############################################################################
@@ -82,6 +82,7 @@ find_package(GLog REQUIRED)
 ExternalProject_Add(
     gtest
     GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG 0fc5466dbb9e623029b1ada539717d10bd45e99e
     TIMEOUT 10
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/third_party/gtest
     # no install required, we link the library from the build tree

--- a/src/base/resource_stats.proto
+++ b/src/base/resource_stats.proto
@@ -21,6 +21,11 @@ message ResourceStats {
   // Network stats in KB
   int64 net_rx_bw = 9;
   int64 net_tx_bw = 10;
+  // Ephemeral Storage
+  int64 ephemeral_storage_allocatable = 11;
+  int64 ephemeral_storage_capacity = 12;
+  double ephemeral_storage_reservation = 13;
+  double ephemeral_storage_utilization = 14;
 }
 
 message CpuStats {

--- a/src/base/resource_vector.proto
+++ b/src/base/resource_vector.proto
@@ -15,4 +15,5 @@ message ResourceVector {
   uint64 disk_cap = 5; // in KB
   uint64 net_tx_bw = 6; // in KB
   uint64 net_rx_bw = 7; // in KB
+  uint64 ephemeral_storage = 8;
 }

--- a/src/scheduling/firmament_scheduler.proto
+++ b/src/scheduling/firmament_scheduler.proto
@@ -36,6 +36,9 @@ message ScheduleRequest {}
 
 message SchedulingDeltas {
   repeated SchedulingDelta deltas = 1;
+  // Added support for events. Added field to collect
+  // unscheduled tasks in a scheduling round.
+  repeated uint64 unscheduled_tasks = 2;
 }
 
 message TaskCompletedResponse {

--- a/src/scheduling/firmament_scheduler_service.cc
+++ b/src/scheduling/firmament_scheduler_service.cc
@@ -53,13 +53,15 @@ using firmament::scheduler::SimpleScheduler;
 using firmament::scheduler::TopologyManager;
 using firmament::platform::sim::SimulatedMessagingAdapter;
 
+DECLARE_bool(gather_unscheduled_tasks);
 DEFINE_string(firmament_scheduler_service_address, "127.0.0.1",
               "The address of the scheduler service");
 DEFINE_string(firmament_scheduler_service_port, "9090",
               "The port of the scheduler service");
 DECLARE_bool(resource_stats_update_based_on_resource_reservation);
 DEFINE_string(service_scheduler, "flow", "Scheduler to use: flow | simple");
-DEFINE_uint64(queue_based_scheduling_time, 100, "Queue Based Schedule run time");
+DEFINE_uint64(queue_based_scheduling_time, 100,
+              "Queue Based Schedule run time");
 
 namespace firmament {
 
@@ -83,6 +85,9 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
           knowledge_base_, topology_manager_, sim_messaging_adapter_, NULL,
           top_level_res_id_, "", &wall_time_, trace_generator_, &labels_map_,
           &affinity_antiaffinity_tasks_);
+      // Get cost model pointer to clear unscheduled tasks of previous
+      // scheduling round and get unscheduled tasks of current scheduling round.
+      cost_model_ = dynamic_cast<FlowScheduler*>(scheduler_)->cost_model();
     } else if (FLAGS_service_scheduler == "simple") {
       scheduler_ = new SimpleScheduler(
           job_map_, resource_map_,
@@ -163,22 +168,72 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
                   SchedulingDeltas* reply) override {
     boost::lock_guard<boost::recursive_mutex> lock(
         scheduler_->scheduling_lock_);
+    // Clear unscheduled tasks related maps and sets of previous scheduling
+    // round.
+    if (FLAGS_gather_unscheduled_tasks) {
+      cost_model_->ClearUnscheduledTasksData();
+    }
     SchedulerStats sstat;
     vector<SchedulingDelta> deltas;
+    // Schedule tasks which does not have pod affinity/anti-affinity
+    // requirements.
     scheduler_->ScheduleAllJobs(&sstat, &deltas);
+    // Get unscheduled tasks of above scheduling round.
+    vector<uint64_t> unscheduled_tasks;
+    if (FLAGS_gather_unscheduled_tasks) {
+      cost_model_->GetUnscheduledTasks(&unscheduled_tasks);
+    }
+
+    // Clear unscheduled tasks related maps and sets of previous scheduling
+    // round.
+    if (FLAGS_gather_unscheduled_tasks) {
+      cost_model_->ClearUnscheduledTasksData();
+    }
     clock_t start = clock();
     uint64_t elapsed = 0;
-    // Schedule tasks having pod affinity/anti-affinity
+    unordered_set<uint64_t> unscheduled_tasks_set;
+    unordered_set<uint64_t> scheduled_tasks_set;
+    // Schedule tasks having pod affinity/anti-affinity.
     while (affinity_antiaffinity_tasks_.size() &&
            (elapsed < FLAGS_queue_based_scheduling_time)) {
-      scheduler_->ScheduleAllQueueJobs(&sstat, &deltas);
+      uint64_t task_scheduled =
+          scheduler_->ScheduleAllQueueJobs(&sstat, &deltas);
+      TaskID_t task_id = dynamic_cast<FlowScheduler*>(scheduler_)
+                             ->GetSingleTaskTobeScheduled();
+      if (!task_scheduled) {
+        if (FLAGS_gather_unscheduled_tasks) {
+          if (unscheduled_tasks_set.find(task_id) ==
+              unscheduled_tasks_set.end()) {
+            unscheduled_tasks_set.insert(task_id);
+            unscheduled_tasks.push_back(task_id);
+          }
+        }
+      } else {
+        if (FLAGS_gather_unscheduled_tasks) {
+          unscheduled_tasks_set.erase(task_id);
+          scheduled_tasks_set.insert(task_id);
+        }
+      }
       clock_t stop = clock();
       elapsed = (double)(stop - start) * 1000.0 / CLOCKS_PER_SEC;
     }
-    // Extract results
-    if (deltas.size()) {
-      LOG(INFO) << "Got " << deltas.size() << " scheduling deltas";
+    // Get unscheduled tasks of above scheduling round which tried scheduling
+    // tasks having pod affinity/anti-affinity. And populate the same into
+    // reply.
+    if (FLAGS_gather_unscheduled_tasks) {
+      LOG(INFO) << "Got " << unscheduled_tasks.size() << " unscheduled tasks";
+      auto unscheduled_tasks_ret = reply->mutable_unscheduled_tasks();
+      for (auto& unsched_task : unscheduled_tasks) {
+        if (scheduled_tasks_set.find(unsched_task) ==
+            scheduled_tasks_set.end()) {
+          uint64_t* unsched_task_ret = unscheduled_tasks_ret->Add();
+          *unsched_task_ret = unsched_task;
+        }
+      }
     }
+
+    // Extract scheduling results.
+    LOG(INFO) << "Got " << deltas.size() << " scheduling deltas";
     for (auto& d : deltas) {
       // LOG(INFO) << "Delta: " << d.DebugString();
       SchedulingDelta* ret_delta = reply->add_deltas();
@@ -559,9 +614,9 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
         rs_ptr->mutable_topology_node(), *updated_rtnd_ptr,
         boost::bind(&FirmamentSchedulerServiceImpl::UpdateNodeLabels, this, _1,
                     _2));
-		DFSTraverseResourceProtobufTreesReturnRTNDs(
-		rs_ptr->mutable_topology_node(), *updated_rtnd_ptr,
-		boost::bind(&FirmamentSchedulerServiceImpl::UpdateNodeTaints, this, _1,
+    DFSTraverseResourceProtobufTreesReturnRTNDs(
+        rs_ptr->mutable_topology_node(), *updated_rtnd_ptr,
+        boost::bind(&FirmamentSchedulerServiceImpl::UpdateNodeTaints, this, _1,
                     _2));
     // TODO(ionel): Support other types of node updates.
     reply->set_type(NodeReplyType::NODE_UPDATED_OK);
@@ -578,17 +633,17 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
       label_ptr->CopyFrom(label);
     }
   }
-  
+
   void UpdateNodeTaints(ResourceTopologyNodeDescriptor* old_rtnd_ptr,
                         const ResourceTopologyNodeDescriptor& new_rtnd_ptr) {
-	ResourceDescriptor* old_rd_ptr = old_rtnd_ptr->mutable_resource_desc();
-    const ResourceDescriptor& new_rd = new_rtnd_ptr.resource_desc();	
-	old_rd_ptr->clear_taints();
-	for (const auto& taint : new_rd.taints()) {
-		Taint* taint_ptr = old_rd_ptr->add_taints();
-		taint_ptr->CopyFrom(taint);
-    	}
-	}
+    ResourceDescriptor* old_rd_ptr = old_rtnd_ptr->mutable_resource_desc();
+    const ResourceDescriptor& new_rd = new_rtnd_ptr.resource_desc();
+    old_rd_ptr->clear_taints();
+    for (const auto& taint : new_rd.taints()) {
+      Taint* taint_ptr = old_rd_ptr->add_taints();
+      taint_ptr->CopyFrom(taint);
+    }
+  }
 
   Status AddTaskStats(ServerContext* context, const TaskStats* task_stats,
                       TaskStatsResponse* reply) override {
@@ -666,6 +721,7 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
   }
   boost::recursive_mutex task_submission_lock_;
   boost::recursive_mutex node_addition_lock_;
+  CostModelInterface* cost_model_;
 };
 
 }  // namespace firmament

--- a/src/scheduling/firmament_scheduler_service.cc
+++ b/src/scheduling/firmament_scheduler_service.cc
@@ -390,7 +390,6 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
       reply->set_type(TaskReplyType::TASK_STATE_NOT_CREATED);
       return Status::OK;
     }
-    LOG(INFO) << "TaskSubmitted: task=" << task_id << ", ephemeral_storage=" << task_desc_ptr->task_descriptor().resource_request().ephemeral_storage();
     AddTaskToLabelsMap(task_desc_ptr->task_descriptor());
     JobID_t job_id = JobIDFromString(task_desc_ptr->task_descriptor().job_id());
     JobDescriptor* jd_ptr = FindOrNull(*job_map_, job_id);
@@ -525,7 +524,6 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
       resource_stats.set_net_rx_bw(0);
       resource_stats.set_net_tx_bw(0);
       // ephemeral storage
-      LOG(INFO) << "NodeAdded: ephemeral_storage=" << rtnd_ptr->resource_desc().resource_capacity().ephemeral_storage();
       resource_stats.set_ephemeral_storage_capacity(
           rtnd_ptr->resource_desc().resource_capacity().ephemeral_storage());
       resource_stats.set_ephemeral_storage_utilization(0.1);

--- a/src/scheduling/firmament_scheduler_service.cc
+++ b/src/scheduling/firmament_scheduler_service.cc
@@ -140,12 +140,20 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
         resource_stats.set_mem_allocatable(
             resource_stats.mem_allocatable() +
             td_ptr->resource_request().ram_cap());
+        // ephemeral storage
+        resource_stats.set_ephemeral_storage_allocatable(
+            resource_stats.ephemeral_storage_allocatable() +
+            td_ptr->resource_request().ephemeral_storage());
       } else {
         cpu_stats->set_cpu_allocatable(cpu_stats->cpu_allocatable() -
                                        td_ptr->resource_request().cpu_cores());
         resource_stats.set_mem_allocatable(
             resource_stats.mem_allocatable() -
             td_ptr->resource_request().ram_cap());
+        // ephemeral storage
+        resource_stats.set_ephemeral_storage_allocatable(
+            resource_stats.ephemeral_storage_allocatable() -
+            td_ptr->resource_request().ephemeral_storage());
       }
       double cpu_utilization =
           (cpu_stats->cpu_capacity() - cpu_stats->cpu_allocatable()) /
@@ -155,6 +163,10 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
           (resource_stats.mem_capacity() - resource_stats.mem_allocatable()) /
           (double)resource_stats.mem_capacity();
       resource_stats.set_mem_utilization(mem_utilization);
+      double ephemeral_storage_utilization =
+          (resource_stats.ephemeral_storage_capacity() - resource_stats.ephemeral_storage_allocatable()) /
+          (double)resource_stats.ephemeral_storage_capacity();
+      resource_stats.set_ephemeral_storage_utilization(ephemeral_storage_utilization);
       knowledge_base_->AddMachineSample(resource_stats);
     }
   }
@@ -378,6 +390,7 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
       reply->set_type(TaskReplyType::TASK_STATE_NOT_CREATED);
       return Status::OK;
     }
+    LOG(INFO) << "TaskSubmitted: task=" << task_id << ", ephemeral_storage=" << task_desc_ptr->task_descriptor().resource_request().ephemeral_storage();
     AddTaskToLabelsMap(task_desc_ptr->task_descriptor());
     JobID_t job_id = JobIDFromString(task_desc_ptr->task_descriptor().job_id());
     JobDescriptor* jd_ptr = FindOrNull(*job_map_, job_id);
@@ -511,6 +524,12 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
       resource_stats.set_disk_bw(0);
       resource_stats.set_net_rx_bw(0);
       resource_stats.set_net_tx_bw(0);
+      // ephemeral storage
+      LOG(INFO) << "NodeAdded: ephemeral_storage=" << rtnd_ptr->resource_desc().resource_capacity().ephemeral_storage();
+      resource_stats.set_ephemeral_storage_capacity(
+          rtnd_ptr->resource_desc().resource_capacity().ephemeral_storage());
+      resource_stats.set_ephemeral_storage_utilization(0.1);
+      resource_stats.set_ephemeral_storage_allocatable(resource_stats.ephemeral_storage_capacity() * 0.9);
       knowledge_base_->AddMachineSample(resource_stats);
     }
     return Status::OK;

--- a/src/scheduling/flow/cost_model_interface.h
+++ b/src/scheduling/flow/cost_model_interface.h
@@ -248,6 +248,20 @@ class CostModelInterface {
     return delta;
   }
 
+  /**
+   * Clear unscheduled tasks related maps and sets.
+   */
+  virtual void ClearUnscheduledTasksData() {
+  }
+
+  /**
+   * Get all task ids which are connected to task EC, in turn task EC
+   * is not connected to any of the machine ecs. i.e get unscheduled
+   * tasks.
+   */
+  virtual void GetUnscheduledTasks(vector<uint64_t>* unscheduled_tasks_ptr) {
+  }
+
  protected:
   shared_ptr<FlowGraphManager> flow_graph_manager_;
 };

--- a/src/scheduling/flow/cpu_cost_model.cc
+++ b/src/scheduling/flow/cpu_cost_model.cc
@@ -433,7 +433,6 @@ vector<EquivClass_t>* CpuCostModel::GetTaskEquivClasses(TaskID_t task_id) {
       task_agg = HashJobID(*td_ptr);
     } else if (task_resource_request->ephemeral_storage_ > 0) {
       //In case if ephemeral storage is specified.
-      LOG(INFO) << "GetTaskEquivClasses: ephemeral storage present for task=" << task_id << ", ephemeral_storage=" << task_resource_request->ephemeral_storage_;
       boost::hash_combine(
           task_agg, to_string(task_resource_request->cpu_cores_) + "cpu" +
                         to_string(task_resource_request->ram_cap_) + "mem" +
@@ -1408,8 +1407,6 @@ vector<EquivClass_t>* CpuCostModel::GetEquivClassToEquivClassesArcs(
           static_cast<uint64_t>(rd.available_resources().ram_cap());
       available_resources.ephemeral_storage_ =
           static_cast<uint64_t>(rd.available_resources().ephemeral_storage());
-      LOG(INFO) << "Machine: " << rd.friendly_name();
-      LOG(INFO) << "GetEquivClassToEquivClassesArcs: available_resources.ephemeral_storage=" << rd.available_resources().ephemeral_storage();
       ResourceID_t res_id = ResourceIDFromString(rd.uuid());
       vector<EquivClass_t>* ecs_for_machine =
           FindOrNull(ecs_for_machines_, res_id);
@@ -1459,7 +1456,6 @@ void CpuCostModel::AddTask(TaskID_t task_id) {
   resource_request.ram_cap_ =
       static_cast<uint64_t>(td.resource_request().ram_cap());
   // ephemeral storage
-  LOG(INFO) << "AddTask: adding to resource_request value=" << td.resource_request().ephemeral_storage();
   resource_request.ephemeral_storage_ =
       static_cast<uint64_t>(td.resource_request().ephemeral_storage());
   CHECK(InsertIfNotPresent(&task_resource_requirement_, task_id,

--- a/src/scheduling/flow/cpu_cost_model.cc
+++ b/src/scheduling/flow/cpu_cost_model.cc
@@ -1463,15 +1463,17 @@ vector<EquivClass_t>* CpuCostModel::GetEquivClassToEquivClassesArcs(
         pref_ecs->push_back(ec_machines.second[index]);
       }
     }
-    if (pref_ecs->size() == 0) {
-      // So tasks connected to this task EC will never be scheduled, so populate
-      // this 'ec' to 'task_ec_with_no_pref_arcs_'. Reason why tasks not
-      // scheduled could be 1) Not enough cpu/mem 2) Any nodes not satisfying
-      // scheduling constraints like affinity etc.
-      if (task_ec_with_no_pref_arcs_set_.find(ec) ==
-          task_ec_with_no_pref_arcs_set_.end()) {
-        task_ec_with_no_pref_arcs_.push_back(ec);
-        task_ec_with_no_pref_arcs_set_.insert(ec);
+    if (FLAGS_gather_unscheduled_tasks) {
+      if (pref_ecs->size() == 0) {
+        // So tasks connected to this task EC will never be scheduled, so populate
+        // this 'ec' to 'task_ec_with_no_pref_arcs_'. Reason why tasks not
+        // scheduled could be 1) Not enough cpu/mem 2) Any nodes not satisfying
+        // scheduling constraints like affinity etc.
+        if (task_ec_with_no_pref_arcs_set_.find(ec) ==
+            task_ec_with_no_pref_arcs_set_.end()) {
+          task_ec_with_no_pref_arcs_.push_back(ec);
+          task_ec_with_no_pref_arcs_set_.insert(ec);
+        }
       }
     }
   }

--- a/src/scheduling/flow/cpu_cost_model.cc
+++ b/src/scheduling/flow/cpu_cost_model.cc
@@ -33,6 +33,7 @@
 DEFINE_uint64(max_multi_arcs_for_cpu, 50, "Maximum number of multi-arcs.");
 
 DECLARE_uint64(max_tasks_per_pu);
+DECLARE_bool(gather_unscheduled_tasks);
 DECLARE_bool(pod_affinity_antiaffinity_symmetry);
 
 namespace firmament {
@@ -64,7 +65,22 @@ void CpuCostModel::AccumulateResourceStats(ResourceDescriptor* accumulator,
                                    other->num_slots_below());
 }
 
-pair<TaskID_t, ResourceID_t> CpuCostModel::GetTaskMappingForSingleTask(TaskID_t task_id) {
+// Events support for firmament.
+void CpuCostModel::ClearUnscheduledTasksData() {
+  // Clear all map and sets related to unscheduled tasks.
+  task_ec_to_connected_tasks_.clear();
+  task_ec_to_connected_tasks_set_.clear();
+  task_ec_with_no_pref_arcs_.clear();
+  task_ec_with_no_pref_arcs_set_.clear();
+}
+
+// Events support for firmament.
+vector<uint64_t>* CpuCostModel::GetTasksConnectedToTaskEC(EquivClass_t ec) {
+  return &task_ec_to_connected_tasks_[ec];
+}
+
+pair<TaskID_t, ResourceID_t> CpuCostModel::GetTaskMappingForSingleTask(
+    TaskID_t task_id) {
   // This function returns best matching resource for given taskid.
   vector<EquivClass_t>* ecs = GetTaskEquivClasses(task_id);
   pair<TaskID_t, ResourceID_t> delta;
@@ -80,6 +96,19 @@ pair<TaskID_t, ResourceID_t> CpuCostModel::GetTaskMappingForSingleTask(TaskID_t 
 #endif
   }
   return delta;
+}
+
+// Events support for firmament.
+void CpuCostModel::GetUnscheduledTasks(
+    vector<uint64_t>* unscheduled_tasks_ptr) {
+  // Return all tasks that are connected to task EC, where task EC has zero
+  // outgoing preferred arcs to machine ecs.
+  for (auto& ec : task_ec_with_no_pref_arcs_) {
+    vector<uint64_t>* tasks_connected_to_ec = GetTasksConnectedToTaskEC(ec);
+    unscheduled_tasks_ptr->insert(std::end(*unscheduled_tasks_ptr),
+                                  std::begin(*tasks_connected_to_ec),
+                                  std::end(*tasks_connected_to_ec));
+  }
 }
 
 ArcDescriptor CpuCostModel::TaskToUnscheduledAgg(TaskID_t task_id) {
@@ -267,46 +296,44 @@ ArcDescriptor CpuCostModel::EquivClassToEquivClass(EquivClass_t ec1,
       pod_affinity_normalized_score = pod_affinity_score.final_score;
     }
   }
-  //Expressing taints/tolerations priority scores
-    unordered_map<ResourceID_t, PriorityScoresList_t,
-                    boost::hash<boost::uuids::uuid>>*
-          taints_priority_scores_ptr =
-              FindOrNull(ec_to_node_priority_scores, ec1);
-      CHECK_NOTNULL(taints_priority_scores_ptr);
-      PriorityScoresList_t* priority_scores_struct_ptr =
-          FindOrNull(*taints_priority_scores_ptr, *machine_res_id);
-      CHECK_NOTNULL(priority_scores_struct_ptr);
-      PriorityScore_t& taints_score =
-          priority_scores_struct_ptr->intolerable_taints_priority;
-      if (taints_score.satisfy) {
-        MinMaxScores_t* max_min_priority_scores =
-            FindOrNull(ec_to_max_min_priority_scores, ec1);
-        CHECK_NOTNULL(max_min_priority_scores);
-        if (taints_score.final_score == -1) {
-          // Normalised taints score is not calculated for this
-          // machine, so calculate and store it once.
-          int64_t max_score =
-              max_min_priority_scores->intolerable_taints_priority.max_score;
-          if (max_score) {
-            taints_score.final_score =  (taints_score.score / (float)(max_score)) * omega_;
-          }
-        }
-      }else{
+  // Expressing taints/tolerations priority scores
+  unordered_map<ResourceID_t, PriorityScoresList_t,
+                boost::hash<boost::uuids::uuid>>* taints_priority_scores_ptr =
+      FindOrNull(ec_to_node_priority_scores, ec1);
+  CHECK_NOTNULL(taints_priority_scores_ptr);
+  PriorityScoresList_t* priority_scores_struct_ptr =
+      FindOrNull(*taints_priority_scores_ptr, *machine_res_id);
+  CHECK_NOTNULL(priority_scores_struct_ptr);
+  PriorityScore_t& taints_score =
+      priority_scores_struct_ptr->intolerable_taints_priority;
+  if (taints_score.satisfy) {
+    MinMaxScores_t* max_min_priority_scores =
+        FindOrNull(ec_to_max_min_priority_scores, ec1);
+    CHECK_NOTNULL(max_min_priority_scores);
+    if (taints_score.final_score == -1) {
+      // Normalised taints score is not calculated for this
+      // machine, so calculate and store it once.
+      int64_t max_score =
+          max_min_priority_scores->intolerable_taints_priority.max_score;
+      if (max_score) {
+        taints_score.final_score =
+            (taints_score.score / (float)(max_score)) * omega_;
+      }
+    }
+  } else {
+    taints_score.final_score = 0;
+  }
 
-	taints_score.final_score = 0;
-     }
-  
   cost_vector.node_affinity_soft_cost_ =
       omega_ - node_affinity_normalized_score;
   cost_vector.pod_affinity_soft_cost_ = omega_ - pod_affinity_normalized_score;
   cost_vector.intolerable_taints_cost_ = taints_score.final_score;
-  
-	
+
   Cost_t final_cost = FlattenCostVector(cost_vector);
-  //Added for solver
+  // Added for solver
   if (pod_affinity_or_anti_affinity_task) {
-    ResourceID_t current_resource_id =
-      ResourceIDFromString(rs->topology_node().children(0).resource_desc().uuid());
+    ResourceID_t current_resource_id = ResourceIDFromString(
+        rs->topology_node().children(0).resource_desc().uuid());
     ResourceID_t* res_id = FindOrNull(ec_to_best_fit_resource_, ec1);
     if (!res_id) {
       ec_to_min_cost_[ec1] = final_cost;
@@ -415,7 +442,8 @@ vector<EquivClass_t>* CpuCostModel::GetTaskEquivClasses(TaskID_t task_id) {
   CHECK_NOTNULL(task_resource_request);
   size_t task_agg = 0;
   bool pod_antiaffinity_symmetry = false;
-  if (td_ptr->has_affinity() || (td_ptr->tolerations_size() > DEFAULT_TOLERATIONS)) {
+  if (td_ptr->has_affinity() ||
+      (td_ptr->tolerations_size() > DEFAULT_TOLERATIONS)) {
     // For tasks which has affinity requirements, we hash the job id.
     // TODO(jagadish): This hash has to be handled in an efficient way in
     // future.
@@ -445,6 +473,31 @@ vector<EquivClass_t>* CpuCostModel::GetTaskEquivClasses(TaskID_t task_id) {
   InsertIfNotPresent(&ec_to_td_requirements, resource_request_ec, *td_ptr);
   if (pod_antiaffinity_symmetry) {
     ecs_with_pod_antiaffinity_symmetry_.insert(resource_request_ec);
+  }
+  if (FLAGS_gather_unscheduled_tasks) {
+    // When preemption is enabled, there is a chance that task can be in
+    // 'RUNNING' state. Skip such tasks. You may need to revisit this code once
+    // preemption code is completed.
+    if (td_ptr->state() != TaskDescriptor::RUNNING) {
+      auto it = task_ec_to_connected_tasks_.find(resource_request_ec);
+      // Make sure we store unique unscheduled task entries.
+      if (it != task_ec_to_connected_tasks_.end()) {
+        unordered_set<uint64_t>& connected_tasks_set =
+            task_ec_to_connected_tasks_set_[resource_request_ec];
+        if (connected_tasks_set.find(task_id) == connected_tasks_set.end()) {
+          it->second.push_back(task_id);
+          connected_tasks_set.insert(task_id);
+        }
+      } else {
+        vector<uint64_t> connected_tasks;
+        unordered_set<uint64_t> connected_tasks_set;
+        connected_tasks.push_back(task_id);
+        task_ec_to_connected_tasks_[resource_request_ec] = connected_tasks;
+        connected_tasks_set.insert(task_id);
+        task_ec_to_connected_tasks_set_[resource_request_ec] =
+            connected_tasks_set;
+      }
+    }
   }
   return ecs;
 }
@@ -556,122 +609,114 @@ void CpuCostModel::CalculatePrioritiesCost(const EquivClass_t ec,
   }
 }
 
-
-//Taints and Tolerations
+// Taints and Tolerations
 void CpuCostModel::CalculateIntolerableTaintsCost(const ResourceDescriptor& rd,
-                                            const TaskDescriptor* td_ptr,
-                                            const EquivClass_t ec ){
- bool IsTolerable = false;
- int64_t intolerable_taint_cost = 0;
- for (const auto& tolerations: td_ptr->tolerations()) {
-         if (tolerations.effect() == "PreferNoSchedule" || tolerations.effect() == ""){
-                if(tolerations.operator_() == "Exists"){
-                               if (tolerations.key() != ""){
-                                       InsertIfNotPresent(&tolerationSoftExistsMap,tolerations.key(),tolerations.value());
-                               }else{
-                                       IsTolerable = true;
-                               }
-
-                        }
-               else if ((tolerations.operator_() == "Equal") || (tolerations.operator_() == "")){
-
-                               InsertIfNotPresent(&tolerationSoftEqualMap,tolerations.key(),tolerations.value());
-
-                        }
-               else{
-                               LOG(FATAL) << "Unsupported operator :" << tolerations.operator_();
-                               break;
-                        }
-
-                }
-
-         }
-
-  if (!IsTolerable){
-       for (const auto& taint : rd.taints()){
-       if (taint.effect() == "PreferNoSchedule"){
-               //If the key does not exist in Exists Map, look for Equal Map for any matching key and value
-
-               if (!ContainsKey(tolerationSoftExistsMap,taint.key())){
-                       const string* value = FindOrNull(tolerationSoftEqualMap, taint.key());
-
-                       //If key is found, then value is not NULL
-                        if (value != NULL) {
-                                //Check if the value matches for the found key
-                                       if ((*value) != taint.value()) {
-                                         intolerable_taint_cost = intolerable_taint_cost + 1;
-                                       }
-                        }else{ //If the key is not found, then taint is not tolerable
-                                       intolerable_taint_cost = intolerable_taint_cost + 1;
-                         }
-
-                       }
-
-               }
-       }
-  }
-     // Fill the intolerable taints priority min, max and actual scores which will
-        // be used in cost calculation.
-        unordered_map<ResourceID_t, PriorityScoresList_t,
-                      boost::hash<boost::uuids::uuid>>*
-            taints_priority_scores_ptr =
-                FindOrNull(ec_to_node_priority_scores, ec);
-        if (!taints_priority_scores_ptr) {
-          // For this EC, no node to priority scores map exists, so initialize
-          // it.
-          unordered_map<ResourceID_t, PriorityScoresList_t,
-                        boost::hash<boost::uuids::uuid>>
-              node_to_priority_scores_map;
-          InsertIfNotPresent(&ec_to_node_priority_scores, ec,
-                             node_to_priority_scores_map);
-          taints_priority_scores_ptr =
-              FindOrNull(ec_to_node_priority_scores, ec);
+                                                  const TaskDescriptor* td_ptr,
+                                                  const EquivClass_t ec) {
+  bool IsTolerable = false;
+  int64_t intolerable_taint_cost = 0;
+  for (const auto& tolerations : td_ptr->tolerations()) {
+    if (tolerations.effect() == "PreferNoSchedule" ||
+        tolerations.effect() == "") {
+      if (tolerations.operator_() == "Exists") {
+        if (tolerations.key() != "") {
+          InsertIfNotPresent(&tolerationSoftExistsMap, tolerations.key(),
+                             tolerations.value());
+        } else {
+          IsTolerable = true;
         }
-        CHECK_NOTNULL(taints_priority_scores_ptr);
-        ResourceID_t res_id = ResourceIDFromString(rd.uuid());
-        PriorityScoresList_t* priority_scores_struct_ptr =
-            FindOrNull(*taints_priority_scores_ptr, res_id);
-        if (!priority_scores_struct_ptr) {
-          // Priority scores is empty for this node, so initialize it zero.
-          PriorityScoresList_t priority_scores_list;
-          InsertIfNotPresent(taints_priority_scores_ptr, res_id,
-                             priority_scores_list);
-          priority_scores_struct_ptr =
-              FindOrNull(*taints_priority_scores_ptr, res_id);
-        }
-        CHECK_NOTNULL(priority_scores_struct_ptr);
-        // Store the intolerable taints min, max and actual priority scores that will
-        // be utilized in calculating normalized cost.
-        PriorityScore_t& taints_score =
-            priority_scores_struct_ptr->intolerable_taints_priority;
-        if (!intolerable_taint_cost) {
-          // If machine does not satisfies soft constraint then we flag machine
-          // such that cost of omega_ is used in cost calculation.
-          taints_score.satisfy = false;
-        }
-        if (taints_score.satisfy) {
-          // Machine satisfies soft constraints.
-          // Store the intolerable taints min, max and actual priority scores.
-          taints_score.score = intolerable_taint_cost;
-          MinMaxScores_t* max_min_priority_scores =
-              FindOrNull(ec_to_max_min_priority_scores, ec);
-          if (!max_min_priority_scores) {
-            MinMaxScores_t priority_scores_list;
-            InsertIfNotPresent(&ec_to_max_min_priority_scores, ec,
-                               priority_scores_list);
-            max_min_priority_scores =
-                FindOrNull(ec_to_max_min_priority_scores, ec);
-          }
-          MinMaxScore_t& min_max_taints_score =
-              max_min_priority_scores->intolerable_taints_priority;
-          if (min_max_taints_score.max_score < intolerable_taint_cost ||
-              min_max_taints_score.max_score == -1) {
-            min_max_taints_score.max_score = intolerable_taint_cost;
-          }
-		}
+
+      } else if ((tolerations.operator_() == "Equal") ||
+                 (tolerations.operator_() == "")) {
+        InsertIfNotPresent(&tolerationSoftEqualMap, tolerations.key(),
+                           tolerations.value());
+
+      } else {
+        LOG(FATAL) << "Unsupported operator :" << tolerations.operator_();
+        break;
       }
+    }
+  }
 
+  if (!IsTolerable) {
+    for (const auto& taint : rd.taints()) {
+      if (taint.effect() == "PreferNoSchedule") {
+        // If the key does not exist in Exists Map, look for Equal Map for any
+        // matching key and value
 
+        if (!ContainsKey(tolerationSoftExistsMap, taint.key())) {
+          const string* value = FindOrNull(tolerationSoftEqualMap, taint.key());
+
+          // If key is found, then value is not NULL
+          if (value != NULL) {
+            // Check if the value matches for the found key
+            if ((*value) != taint.value()) {
+              intolerable_taint_cost = intolerable_taint_cost + 1;
+            }
+          } else {  // If the key is not found, then taint is not tolerable
+            intolerable_taint_cost = intolerable_taint_cost + 1;
+          }
+        }
+      }
+    }
+  }
+  // Fill the intolerable taints priority min, max and actual scores which will
+  // be used in cost calculation.
+  unordered_map<ResourceID_t, PriorityScoresList_t,
+                boost::hash<boost::uuids::uuid>>* taints_priority_scores_ptr =
+      FindOrNull(ec_to_node_priority_scores, ec);
+  if (!taints_priority_scores_ptr) {
+    // For this EC, no node to priority scores map exists, so initialize
+    // it.
+    unordered_map<ResourceID_t, PriorityScoresList_t,
+                  boost::hash<boost::uuids::uuid>>
+        node_to_priority_scores_map;
+    InsertIfNotPresent(&ec_to_node_priority_scores, ec,
+                       node_to_priority_scores_map);
+    taints_priority_scores_ptr = FindOrNull(ec_to_node_priority_scores, ec);
+  }
+  CHECK_NOTNULL(taints_priority_scores_ptr);
+  ResourceID_t res_id = ResourceIDFromString(rd.uuid());
+  PriorityScoresList_t* priority_scores_struct_ptr =
+      FindOrNull(*taints_priority_scores_ptr, res_id);
+  if (!priority_scores_struct_ptr) {
+    // Priority scores is empty for this node, so initialize it zero.
+    PriorityScoresList_t priority_scores_list;
+    InsertIfNotPresent(taints_priority_scores_ptr, res_id,
+                       priority_scores_list);
+    priority_scores_struct_ptr =
+        FindOrNull(*taints_priority_scores_ptr, res_id);
+  }
+  CHECK_NOTNULL(priority_scores_struct_ptr);
+  // Store the intolerable taints min, max and actual priority scores that will
+  // be utilized in calculating normalized cost.
+  PriorityScore_t& taints_score =
+      priority_scores_struct_ptr->intolerable_taints_priority;
+  if (!intolerable_taint_cost) {
+    // If machine does not satisfies soft constraint then we flag machine
+    // such that cost of omega_ is used in cost calculation.
+    taints_score.satisfy = false;
+  }
+  if (taints_score.satisfy) {
+    // Machine satisfies soft constraints.
+    // Store the intolerable taints min, max and actual priority scores.
+    taints_score.score = intolerable_taint_cost;
+    MinMaxScores_t* max_min_priority_scores =
+        FindOrNull(ec_to_max_min_priority_scores, ec);
+    if (!max_min_priority_scores) {
+      MinMaxScores_t priority_scores_list;
+      InsertIfNotPresent(&ec_to_max_min_priority_scores, ec,
+                         priority_scores_list);
+      max_min_priority_scores = FindOrNull(ec_to_max_min_priority_scores, ec);
+    }
+    MinMaxScore_t& min_max_taints_score =
+        max_min_priority_scores->intolerable_taints_priority;
+    if (min_max_taints_score.max_score < intolerable_taint_cost ||
+        min_max_taints_score.max_score == -1) {
+      min_max_taints_score.max_score = intolerable_taint_cost;
+    }
+  }
+}
 
 // Pod affinity/anti-affinity
 bool CpuCostModel::MatchExpressionWithPodLabels(
@@ -873,7 +918,7 @@ bool CpuCostModel::SatisfiesPodAntiAffinityTerm(
         return false;
     }
   }
-   namespaces.clear();
+  namespaces.clear();
   return true;
 }
 
@@ -1023,7 +1068,6 @@ int64_t CpuCostModel::CalculatePodAntiAffinitySymmetryPreference(
   return sum_of_weights;
 }
 
-
 // Soft constraint check for pod affinity/anti-affinity.
 void CpuCostModel::CalculatePodAffinityAntiAffinityPreference(
     const ResourceDescriptor& rd, const TaskDescriptor& td,
@@ -1109,10 +1153,8 @@ void CpuCostModel::CalculatePodAffinityAntiAffinityPreference(
       FindOrNull(*nodes_priority_scores_ptr, res_id);
   if (!priority_scores_struct_ptr) {
     PriorityScoresList_t priority_scores_list;
-    InsertIfNotPresent(nodes_priority_scores_ptr, res_id,
-                       priority_scores_list);
-    priority_scores_struct_ptr =
-        FindOrNull(*nodes_priority_scores_ptr, res_id);
+    InsertIfNotPresent(nodes_priority_scores_ptr, res_id, priority_scores_list);
+    priority_scores_struct_ptr = FindOrNull(*nodes_priority_scores_ptr, res_id);
   }
   CHECK_NOTNULL(priority_scores_struct_ptr);
   PriorityScore_t& pod_affinity_score =
@@ -1353,9 +1395,9 @@ vector<EquivClass_t>* CpuCostModel::GetEquivClassToEquivClassesArcs(
     // scores. But we are not clearing it just after scheduling round completed,
     // we are clearing in the subsequent scheduling round, need to improve this.
     ec_to_node_priority_scores.clear();
-	//Added to clear the map before filling the values for each node
-	tolerationSoftEqualMap.clear();
-	tolerationSoftExistsMap.clear();
+    // Added to clear the map before filling the values for each node
+    tolerationSoftEqualMap.clear();
+    tolerationSoftExistsMap.clear();
     for (auto& ec_machines : ecs_for_machines_) {
       ResourceStatus* rs = FindPtrOrNull(*resource_map_, ec_machines.first);
       CHECK_NOTNULL(rs);
@@ -1374,19 +1416,22 @@ vector<EquivClass_t>* CpuCostModel::GetEquivClassToEquivClassesArcs(
         } else {
           continue;
         }
-		//Check whether taints in the machine has matching tolerations
-		if (scheduler::HasMatchingTolerationforNodeTaints(rd, *td_ptr)) {
-		  CalculateIntolerableTaintsCost(rd, td_ptr, ec);
-		}else {
-                 continue;
+        // Check whether taints in the machine has matching tolerations
+        if (scheduler::HasMatchingTolerationforNodeTaints(rd, *td_ptr)) {
+          CalculateIntolerableTaintsCost(rd, td_ptr, ec);
+        } else {
+          continue;
         }
-		// Checking costs for intolerable taints
-		
+        // Checking costs for intolerable taints
+
         // Checking pod anti-affinity symmetry
-        if (FLAGS_pod_affinity_antiaffinity_symmetry && (ecs_with_pod_antiaffinity_symmetry_.find(ec) != ecs_with_pod_antiaffinity_symmetry_.end())) {
+        if (FLAGS_pod_affinity_antiaffinity_symmetry &&
+            (ecs_with_pod_antiaffinity_symmetry_.find(ec) !=
+             ecs_with_pod_antiaffinity_symmetry_.end())) {
           if (td_ptr->labels_size()) {
-            if (SatisfiesPodAntiAffinitySymmetry(ResourceIDFromString(rd.uuid()), *td_ptr)) {
-              //Calculate soft constriants score if needed.
+            if (SatisfiesPodAntiAffinitySymmetry(
+                    ResourceIDFromString(rd.uuid()), *td_ptr)) {
+              // Calculate soft constriants score if needed.
             } else {
               continue;
             }
@@ -1405,15 +1450,28 @@ vector<EquivClass_t>* CpuCostModel::GetEquivClassToEquivClassesArcs(
       uint64_t index = 0;
       CpuMemResVector_t cur_resource;
       uint64_t task_count = rd.num_running_tasks_below();
-      //TODO(dujun) : FLAGS_max_tasks_per_pu is treated as equivalent to max-pods,
-      // as max-pods functionality is not yet merged at this point.
+      // TODO(pratik) : FLAGS_max_tasks_per_pu is treated as equivalent to
+      // max-pods, as max-pods functionality is not yet merged at this point.
       for (cur_resource = *task_resource_request;
            cur_resource.cpu_cores_ <= available_resources.cpu_cores_ &&
            cur_resource.ram_cap_ <= available_resources.ram_cap_ &&
-           index < ecs_for_machine->size() && task_count < FLAGS_max_tasks_per_pu;
+           index < ecs_for_machine->size() &&
+           task_count < FLAGS_max_tasks_per_pu;
            cur_resource.cpu_cores_ += task_resource_request->cpu_cores_,
-          cur_resource.ram_cap_ += task_resource_request->ram_cap_, index++, task_count++) {
+          cur_resource.ram_cap_ += task_resource_request->ram_cap_, index++,
+          task_count++) {
         pref_ecs->push_back(ec_machines.second[index]);
+      }
+    }
+    if (pref_ecs->size() == 0) {
+      // So tasks connected to this task EC will never be scheduled, so populate
+      // this 'ec' to 'task_ec_with_no_pref_arcs_'. Reason why tasks not
+      // scheduled could be 1) Not enough cpu/mem 2) Any nodes not satisfying
+      // scheduling constraints like affinity etc.
+      if (task_ec_with_no_pref_arcs_set_.find(ec) ==
+          task_ec_with_no_pref_arcs_set_.end()) {
+        task_ec_with_no_pref_arcs_.push_back(ec);
+        task_ec_with_no_pref_arcs_set_.insert(ec);
       }
     }
   }

--- a/src/scheduling/flow/cpu_cost_model.h
+++ b/src/scheduling/flow/cpu_cost_model.h
@@ -202,6 +202,12 @@ class CpuCostModel : public CostModelInterface {
   void PrepareStats(FlowGraphNode* accumulator);
   FlowGraphNode* UpdateStats(FlowGraphNode* accumulator, FlowGraphNode* other);
   pair<TaskID_t, ResourceID_t> GetTaskMappingForSingleTask(TaskID_t task_id);
+  // Get all the tasks that are connected to task EC.
+  vector<uint64_t>* GetTasksConnectedToTaskEC(TaskID_t task_id);
+  // Clear unscheduled tasks related maps and sets.
+  void ClearUnscheduledTasksData();
+  // Get unscheduled tasks in a scheduling round.
+  void GetUnscheduledTasks(vector<uint64_t>* unscheduled_tasks_ptr);
 
  private:
   // Fixed value for OMEGA, the normalization ceiling for each dimension's cost
@@ -268,6 +274,11 @@ class CpuCostModel : public CostModelInterface {
   unordered_map<EquivClass_t, Cost_t> ec_to_min_cost_;
   unordered_map<string, string> tolerationSoftEqualMap;
   unordered_map<string, string> tolerationSoftExistsMap;
+  unordered_set<EquivClass_t> task_ec_with_no_pref_arcs_set_;
+  vector<EquivClass_t> task_ec_with_no_pref_arcs_;
+  unordered_map<EquivClass_t, vector<uint64_t>> task_ec_to_connected_tasks_;
+  unordered_map<EquivClass_t, unordered_set<uint64_t>>
+    task_ec_to_connected_tasks_set_;
 };
 
 }  // namespace firmament

--- a/src/scheduling/flow/cpu_cost_model.h
+++ b/src/scheduling/flow/cpu_cost_model.h
@@ -54,6 +54,7 @@ struct CpuMemCostVector_t {
 struct CpuMemResVector_t {
   uint64_t cpu_cores_;
   uint64_t ram_cap_;
+  uint64_t ephemeral_storage_;
 };
 
 struct MinMaxScore_t {

--- a/src/scheduling/flow/flow_scheduler.cc
+++ b/src/scheduling/flow/flow_scheduler.cc
@@ -221,6 +221,10 @@ uint64_t FlowScheduler::ApplySchedulingDeltas(
           resource_stats.set_mem_allocatable(
               resource_stats.mem_allocatable() -
               td_ptr->resource_request().ram_cap());
+          // ephemeral storage
+          resource_stats.set_ephemeral_storage_allocatable(
+              resource_stats.ephemeral_storage_allocatable() -
+              td_ptr->resource_request().ephemeral_storage());
           double cpu_utilization =
               (cpu_stats->cpu_capacity() - cpu_stats->cpu_allocatable()) /
               (double)cpu_stats->cpu_capacity();
@@ -229,6 +233,10 @@ uint64_t FlowScheduler::ApplySchedulingDeltas(
                                     resource_stats.mem_allocatable()) /
                                    (double)resource_stats.mem_capacity();
           resource_stats.set_mem_utilization(mem_utilization);
+          double ephemeral_storage_utilization = (resource_stats.ephemeral_storage_capacity() -
+                                    resource_stats.ephemeral_storage_allocatable()) /
+                                   (double)resource_stats.ephemeral_storage_capacity();
+          resource_stats.set_ephemeral_storage_utilization(ephemeral_storage_utilization);
           knowledge_base_->AddMachineSample(resource_stats);
         }
       }
@@ -256,6 +264,9 @@ uint64_t FlowScheduler::ApplySchedulingDeltas(
           resource_stats.set_mem_allocatable(
               resource_stats.mem_allocatable() +
               td_ptr->resource_request().ram_cap());
+          resource_stats.set_ephemeral_storage_allocatable(
+              resource_stats.ephemeral_storage_allocatable() +
+              td_ptr->resource_request().ephemeral_storage());
           double cpu_utilization =
               (cpu_stats->cpu_capacity() - cpu_stats->cpu_allocatable()) /
               (double)cpu_stats->cpu_capacity();
@@ -264,6 +275,10 @@ uint64_t FlowScheduler::ApplySchedulingDeltas(
                                     resource_stats.mem_allocatable()) /
                                    (double)resource_stats.mem_capacity();
           resource_stats.set_mem_utilization(mem_utilization);
+          double ephemeral_storage_utilization = (resource_stats.ephemeral_storage_capacity() -
+                                    resource_stats.ephemeral_storage_allocatable()) /
+                                   (double)resource_stats.ephemeral_storage_capacity();
+          resource_stats.set_ephemeral_storage_utilization(ephemeral_storage_utilization);
           knowledge_base_->AddMachineSample(resource_stats);
         }
       }

--- a/src/scheduling/flow/flow_scheduler.h
+++ b/src/scheduling/flow/flow_scheduler.h
@@ -108,10 +108,16 @@ class FlowScheduler : public EventDrivenScheduler {
   const CostModelInterface& cost_model() const {
     return *cost_model_;
   }
+  CostModelInterface* cost_model() {
+    return cost_model_;
+  }
   const SolverDispatcher& dispatcher() const {
     return *solver_dispatcher_;
   }
 
+  TaskID_t GetSingleTaskTobeScheduled() {
+    return task_to_be_scheduled_;
+  }
  protected:
   virtual void HandleTaskMigration(TaskDescriptor* td_ptr,
                                    ResourceDescriptor* rd_ptr);
@@ -154,6 +160,8 @@ class FlowScheduler : public EventDrivenScheduler {
   DIMACSChangeStats* dimacs_stats_;
   uint64_t solver_run_cnt_;
   unordered_set<ResourceTopologyNodeDescriptor*> resource_roots_;
+  // Single task that needs to scheduled in queue based scheduling round.
+  TaskID_t task_to_be_scheduled_;
 };
 
 }  // namespace scheduler


### PR DESCRIPTION
Adding Events support in Firmament.
This feature will send info about unscheduled tasks to Poseidon along with the scheduling deltas, based on which Poseidon will broadcast the events to the api-server.