### PR TITLE
Ephemeral overcommit issue fix

### DIFF
--- a/src/scheduling/firmament_scheduler_service.cc
+++ b/src/scheduling/firmament_scheduler_service.cc
@@ -586,20 +586,34 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
       // utilization to 10%.
       cpu_stats->set_cpu_capacity(
           rtnd_ptr->resource_desc().resource_capacity().cpu_cores());
-      cpu_stats->set_cpu_utilization(0.1);
-      cpu_stats->set_cpu_allocatable(cpu_stats->cpu_capacity() * 0.9);
+      cpu_stats->set_cpu_allocatable(
+          rtnd_ptr->resource_desc().available_resources().cpu_cores());
+      double cpu_utilization =
+          (cpu_stats->cpu_capacity() - cpu_stats->cpu_allocatable()) /
+          (double)cpu_stats->cpu_capacity();
+      cpu_stats->set_cpu_utilization(cpu_utilization);
       resource_stats.set_mem_capacity(
           rtnd_ptr->resource_desc().resource_capacity().ram_cap());
-      resource_stats.set_mem_utilization(0.1);
-      resource_stats.set_mem_allocatable(resource_stats.mem_capacity() * 0.9);
+      resource_stats.set_mem_allocatable(
+          rtnd_ptr->resource_desc().available_resources().ram_cap());
+      double mem_utilization =
+          (resource_stats.mem_capacity() - resource_stats.mem_allocatable()) /
+          (double)resource_stats.mem_capacity();
+      resource_stats.set_mem_utilization(mem_utilization);
       resource_stats.set_disk_bw(0);
       resource_stats.set_net_rx_bw(0);
       resource_stats.set_net_tx_bw(0);
       // ephemeral storage
       resource_stats.set_ephemeral_storage_capacity(
           rtnd_ptr->resource_desc().resource_capacity().ephemeral_storage());
-      resource_stats.set_ephemeral_storage_utilization(0.1);
-      resource_stats.set_ephemeral_storage_allocatable(resource_stats.ephemeral_storage_capacity() * 0.9);
+      resource_stats.set_ephemeral_storage_allocatable(
+          rtnd_ptr->resource_desc().available_resources().ephemeral_storage());
+      double ephemeral_storage_utilization =
+          (resource_stats.ephemeral_storage_capacity() -
+           resource_stats.ephemeral_storage_allocatable()) /
+          (double)resource_stats.ephemeral_storage_capacity();
+      resource_stats.set_ephemeral_storage_utilization(
+                                             ephemeral_storage_utilization);
       knowledge_base_->AddMachineSample(resource_stats);
     }
     return Status::OK;

--- a/src/scheduling/flow/cpu_cost_model.cc
+++ b/src/scheduling/flow/cpu_cost_model.cc
@@ -1462,9 +1462,9 @@ vector<EquivClass_t>* CpuCostModel::GetEquivClassToEquivClassesArcs(
       //TODO(Pratik) : FLAGS_max_tasks_per_pu is treated as equivalent to max-pods,
       // as max-pods functionality is not yet merged at this point.
       for (cur_resource = *task_resource_request;
-           cur_resource.cpu_cores_ <= available_resources.cpu_cores_ &&
-           cur_resource.ram_cap_ <= available_resources.ram_cap_ &&
-           cur_resource.ephemeral_storage_ <= available_resources.ephemeral_storage_ &&
+           cur_resource.cpu_cores_ < available_resources.cpu_cores_ &&
+           cur_resource.ram_cap_ < available_resources.ram_cap_ &&
+           cur_resource.ephemeral_storage_ < available_resources.ephemeral_storage_ &&
            index < ecs_for_machine->size() && task_count < FLAGS_max_tasks_per_pu;
            cur_resource.cpu_cores_ += task_resource_request->cpu_cores_,
           cur_resource.ram_cap_ += task_resource_request->ram_cap_,


### PR DESCRIPTION
This PR addressed the overcommit issue with the Ephemeral e2e sig-scheduling test case.
Prior to this fix the Ephemeral units were converted to KB and hence there was a loss of bytes in conversion, this PR addresses this issue.