### PR TITLE
PreferAvoid pods feature

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -16,6 +16,7 @@ set(BASE_PROTOBUFS
   base/pod_anti_affinity.proto
   base/reference_desc.proto
   base/taints.proto
+  base/avoid_pods_annotation.proto
   base/resource_desc.proto
   base/resource_stats.proto
   base/resource_topology_node_desc.proto

--- a/src/base/avoid_pods_annotation.proto
+++ b/src/base/avoid_pods_annotation.proto
@@ -1,0 +1,12 @@
+// The Firmament project
+// Copyright (c) The Firmament Authors.
+//
+
+syntax = "proto3";
+
+package firmament;
+
+message AvoidPodsAnnotation {
+  string kind = 1;
+  string uid = 2;
+}

--- a/src/base/resource_desc.proto
+++ b/src/base/resource_desc.proto
@@ -12,6 +12,7 @@ import "base/label.proto";
 import "base/resource_vector.proto";
 import "base/whare_map_stats.proto";
 import "base/taints.proto";
+import "base/avoid_pods_annotation.proto";
 
 message ResourceDescriptor {
   enum ResourceState {
@@ -65,4 +66,6 @@ message ResourceDescriptor {
   repeated Label labels = 32;
   //Taints 
   repeated Taint taints = 33;
+  // Avoid pods annotations
+  repeated AvoidPodsAnnotation avoids = 34;
 }

--- a/src/base/task_desc.proto
+++ b/src/base/task_desc.proto
@@ -94,6 +94,8 @@ message TaskDescriptor {
   string task_namespace = 35;
   // Tolerations
   repeated Toleration tolerations = 36;
-  // Owner refernce kind
+  // Owner reference kind
   string owner_ref_kind = 37;
+  //Owner reference uid
+  string owner_ref_uid = 38;
 }

--- a/src/base/task_desc.proto
+++ b/src/base/task_desc.proto
@@ -94,4 +94,6 @@ message TaskDescriptor {
   string task_namespace = 35;
   // Tolerations
   repeated Toleration tolerations = 36;
+  // Owner refernce kind
+  string owner_ref_kind = 37;
 }

--- a/src/scheduling/flow/cpu_cost_model.cc
+++ b/src/scheduling/flow/cpu_cost_model.cc
@@ -325,21 +325,25 @@ ArcDescriptor CpuCostModel::EquivClassToEquivClass(EquivClass_t ec1,
   }
  
   // Expressing avoid pods priority scores
-  unordered_map<ResourceID_t, PriorityScoresList_t,
+  if (rd.avoids_size()) {
+    unordered_map<ResourceID_t, PriorityScoresList_t,
             boost::hash<boost::uuids::uuid>>* avoid_pods_priority_scores_ptr =
                                   FindOrNull(ec_to_node_priority_scores, ec1);
-  CHECK_NOTNULL(avoid_pods_priority_scores_ptr);
-  PriorityScoresList_t* avoid_pods_scores_struct_ptr =
-      FindOrNull(*avoid_pods_priority_scores_ptr, *machine_res_id);
-  CHECK_NOTNULL(avoid_pods_scores_struct_ptr);
-  PriorityScore_t& prefer_avoid_pods_score =
-      avoid_pods_scores_struct_ptr->prefer_avoid_pods_priority;
+    CHECK_NOTNULL(avoid_pods_priority_scores_ptr);
+    PriorityScoresList_t* avoid_pods_scores_struct_ptr =
+        FindOrNull(*avoid_pods_priority_scores_ptr, *machine_res_id);
+    CHECK_NOTNULL(avoid_pods_scores_struct_ptr);
+    PriorityScore_t& prefer_avoid_pods_score =
+        avoid_pods_scores_struct_ptr->prefer_avoid_pods_priority;
+    cost_vector.prefer_avoid_pods_cost_ = prefer_avoid_pods_score.score;
+  } else {
+    cost_vector.prefer_avoid_pods_cost_ = 0;
+  }
 
   cost_vector.node_affinity_soft_cost_ =
       omega_ - node_affinity_normalized_score;
   cost_vector.pod_affinity_soft_cost_ = omega_ - pod_affinity_normalized_score;
   cost_vector.intolerable_taints_cost_ = taints_score.final_score;
-  cost_vector.prefer_avoid_pods_cost_ = prefer_avoid_pods_score.score;
 
   Cost_t final_cost = FlattenCostVector(cost_vector);
   // Added for solver
@@ -1502,7 +1506,9 @@ vector<EquivClass_t>* CpuCostModel::GetEquivClassToEquivClassesArcs(
         }
 
         // Calculate prefer avoid pods priority for node
-        CalculateNodePreferAvoidPodsPriority(rd, *td_ptr, ec);
+        if (rd.avoids_size()) {
+          CalculateNodePreferAvoidPodsPriority(rd, *td_ptr, ec);
+        }
       }
       CpuMemResVector_t available_resources;
       available_resources.cpu_cores_ =

--- a/src/scheduling/flow/cpu_cost_model.h
+++ b/src/scheduling/flow/cpu_cost_model.h
@@ -43,12 +43,14 @@ struct CpuMemCostVector_t {
   uint64_t node_affinity_soft_cost_;
   uint64_t pod_affinity_soft_cost_;
   uint64_t intolerable_taints_cost_;
+  uint64_t prefer_avoid_pods_cost_;
   CpuMemCostVector_t()
       : cpu_mem_cost_(0),
         balanced_res_cost_(0),
         node_affinity_soft_cost_(0),
         pod_affinity_soft_cost_(0),
-	intolerable_taints_cost_(0) {}
+	intolerable_taints_cost_(0),
+        prefer_avoid_pods_cost_(0) {}
 };
 
 struct CpuMemResVector_t {
@@ -81,6 +83,7 @@ struct PriorityScoresList_t {
   PriorityScore_t node_affinity_priority;
   PriorityScore_t pod_affinity_priority;
   PriorityScore_t intolerable_taints_priority;
+  PriorityScore_t prefer_avoid_pods_priority;
 };
 
 class CpuCostModel : public CostModelInterface {
@@ -157,6 +160,9 @@ class CpuCostModel : public CostModelInterface {
   void CalculateIntolerableTaintsCost(const ResourceDescriptor& rd,
                                                   const TaskDescriptor* td,
                                                   const EquivClass_t ec);
+  void CalculateNodePreferAvoidPodsPriority(const ResourceDescriptor rd,
+                                            const TaskDescriptor td,
+                                            const EquivClass_t ec);
   // Pod affinity/anti-affinity symmetry
   bool CheckPodAffinityAntiAffinitySymmetryConflict(TaskDescriptor* td_ptr);
   void UpdateResourceToTaskSymmetryMap(ResourceID_t res_id, TaskID_t td);


### PR DESCRIPTION
This PR added the 'PreferAvoid' Pods annotation in Firmament.
Without this feature there was an sig-scheduling e2e test case which was failing, now after this fix those test cases are passing.