### PR TITLE
Pod Affinity/Anti-Affinity optimization

### DIFF
--- a/src/scheduling/event_driven_scheduler.cc
+++ b/src/scheduling/event_driven_scheduler.cc
@@ -121,6 +121,8 @@ void EventDrivenScheduler::AddPodAffinityAntiAffinityJobData(
     }
     if (no_conflict_within) {
       no_conflict_root_tasks_.insert(rtd.uid());
+      unordered_set<TaskID_t> children_set;
+      InsertIfNotPresent(&root_to_children_tasks_, rtd.uid(), children_set);
     } else {
       if (jd_ptr->is_gang_scheduling_job()) {
         vector<SchedulingDelta> delta_v;

--- a/src/scheduling/event_driven_scheduler.h
+++ b/src/scheduling/event_driven_scheduler.h
@@ -212,6 +212,7 @@ class EventDrivenScheduler : public SchedulerInterface {
   bool affinity_batch_schedule;
   unordered_map<TaskID_t, vector<TaskID_t>> no_conflict_tasks_map_;
   unordered_map<TaskID_t, TaskID_t> no_conflict_task_mapped_;
+  unordered_map<TaskID_t, unordered_set<TaskID_t>> root_to_children_tasks_;
 };
 
 }  // namespace scheduler

--- a/src/scheduling/event_driven_scheduler.h
+++ b/src/scheduling/event_driven_scheduler.h
@@ -145,6 +145,20 @@ class EventDrivenScheduler : public SchedulerInterface {
                 bool local,
                 bool simulated);
   bool UnbindTaskFromResource(TaskDescriptor* td_ptr, ResourceID_t res_id);
+  void AddPodAffinityAntiAffinityJobData(JobDescriptor* jd_ptr);
+  bool MatchExpressionWithPodLabels(unordered_map<string, string>& labels,
+                                 const LabelSelectorRequirement& expression);
+  bool NotMatchExpressionWithPodLabels(unordered_map<string, string>& labels,
+                                 const LabelSelectorRequirement& expression);
+  bool MatchExpressionKeyWithPodLabels(unordered_map<string, string>& labels,
+                                 const LabelSelectorRequirement& expression);
+  bool NotMatchExpressionKeyWithPodLabels(unordered_map<string, string>& labels,
+                                 const LabelSelectorRequirement& expression);
+  bool CheckPodAffinityNoConflictWithin(TaskDescriptor* td_ptr,
+                                      TaskDescriptor* other_rtd);
+  bool CheckPodAntiAffinityNoConflictWithin(TaskDescriptor* rtd,
+                                          TaskDescriptor* other_rtd);
+  unordered_set<TaskID_t>* GetNoConflictTasksSet();
 
   // Cached sets of runnable and blocked tasks; these are updated on each
   // execution of LazyGraphReduction. Note that this set includes tasks from all
@@ -194,6 +208,10 @@ class EventDrivenScheduler : public SchedulerInterface {
   // Pod affinity/anti-affinity gang schedule tasks deltas
   unordered_map<JobDescriptor*, vector<SchedulingDelta>> affinity_job_to_deltas_;
   unordered_set<uint64_t> affinity_delta_tasks;
+  unordered_set<TaskID_t> no_conflict_root_tasks_;
+  bool affinity_batch_schedule;
+  unordered_map<TaskID_t, vector<TaskID_t>> no_conflict_tasks_map_;
+  unordered_map<TaskID_t, TaskID_t> no_conflict_task_mapped_;
 };
 
 }  // namespace scheduler

--- a/src/scheduling/firmament_scheduler_service.cc
+++ b/src/scheduling/firmament_scheduler_service.cc
@@ -272,14 +272,22 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
     // Schedule tasks which does not have pod affinity/anti-affinity
     // requirements.
     scheduler_->ScheduleAllJobs(&sstat, &deltas);
+
     uint64_t total_unsched_tasks_size = 0;
-    vector<uint64_t> unscheduled_normal_tasks;
+    vector<uint64_t> unscheduled_batch_tasks;
     if (FLAGS_gather_unscheduled_tasks) {
       // Get unscheduled tasks of above scheduling round.
-      cost_model_->GetUnscheduledTasks(&unscheduled_normal_tasks);
+      cost_model_->GetUnscheduledTasks(&unscheduled_batch_tasks);
     }
+    // [pod affinity/anti-affinity batch schedule]
+    vector<TaskID_t>* unsched_batch_affinity_tasks =
+                  scheduler_->ScheduleAllAffinityBatchJobs(&sstat, &deltas);
+    for (auto unsched_batch_affinity_task : *unsched_batch_affinity_tasks) {
+      unscheduled_batch_tasks.push_back(unsched_batch_affinity_task);
+    }
+    delete unsched_batch_affinity_tasks;
 
-    // Schedule tasks having pod affinity/anti-affinity.
+    // Queue schedule tasks having pod affinity/anti-affinity.
     clock_t start = clock();
     uint64_t elapsed = 0;
     unordered_set<uint64_t> unscheduled_affinity_tasks_set;
@@ -292,37 +300,36 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
                              ->GetSingleTaskTobeScheduled();
       if (FLAGS_gather_unscheduled_tasks) {
         TaskDescriptor* td_ptr = FindPtrOrNull(*task_map_, task_id);
-        CHECK_NOTNULL(td_ptr);
-        JobDescriptor* jd =
+        if (td_ptr) {
+          JobDescriptor* jd =
                   FindOrNull(*job_map_, JobIDFromString(td_ptr->job_id()));
-        if (!(jd->is_gang_scheduling_job())) {
-          if (!task_scheduled) {
-            if (unscheduled_affinity_tasks_set.find(task_id) ==
-                unscheduled_affinity_tasks_set.end()) {
-              unscheduled_affinity_tasks_set.insert(task_id);
-              unscheduled_affinity_tasks.push_back(task_id);
+          if (!(jd->is_gang_scheduling_job())) {
+            if (!task_scheduled) {
+              if (unscheduled_affinity_tasks_set.find(task_id) ==
+                                    unscheduled_affinity_tasks_set.end()) {
+                unscheduled_affinity_tasks_set.insert(task_id);
+                unscheduled_affinity_tasks.push_back(task_id);
+              }
+            } else {
+              unscheduled_affinity_tasks_set.erase(task_id);
             }
-          } else {
-            unscheduled_affinity_tasks_set.erase(task_id);
           }
         }
       }
       clock_t stop = clock();
       elapsed = (double)(stop - start) * 1000.0 / CLOCKS_PER_SEC;
     }
-    //For pod affinity/anti-affinity gang scheduling tasks
     scheduler_->UpdateGangSchedulingDeltas(&sstat, &deltas,
-                                &unscheduled_normal_tasks,
+                                &unscheduled_batch_tasks,
                                 &unscheduled_affinity_tasks_set,
                                 &unscheduled_affinity_tasks);
-
     // Get unscheduled tasks of above scheduling round which tried scheduling
     // tasks having pod affinity/anti-affinity. And populate the same into
     // reply.
     if (FLAGS_gather_unscheduled_tasks) {
-      auto unscheduled_normal_tasks_ret = reply->mutable_unscheduled_tasks();
-      for (auto& unsched_task : unscheduled_normal_tasks) {
-        uint64_t* unsched_task_ret = unscheduled_normal_tasks_ret->Add();
+      auto unscheduled_batch_tasks_ret = reply->mutable_unscheduled_tasks();
+      for (auto& unsched_task : unscheduled_batch_tasks) {
+        uint64_t* unsched_task_ret = unscheduled_batch_tasks_ret->Add();
         *unsched_task_ret = unsched_task;
         total_unsched_tasks_size++;
       }
@@ -523,7 +530,13 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
     }
     if (td.has_affinity() && (td.affinity().has_pod_affinity() ||
                               td.affinity().has_pod_anti_affinity())) {
-      affinity_antiaffinity_tasks_.push_back(task_id);
+      unordered_set<TaskID_t>* no_conflict_tasks =
+                               scheduler_->GetNoConflictTasksSet();
+      JobID_t job_id = JobIDFromString(td.job_id());
+      JobDescriptor* jd_ptr = FindOrNull(*job_map_, job_id);
+      if (no_conflict_tasks->find(jd_ptr->root_task().uid()) == no_conflict_tasks->end()) {
+        affinity_antiaffinity_tasks_.push_back(task_id);
+      }
     }
   }
 
@@ -541,7 +554,6 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
       reply->set_type(TaskReplyType::TASK_STATE_NOT_CREATED);
       return Status::OK;
     }
-    AddTaskToLabelsMap(task_desc_ptr->task_descriptor());
     JobID_t job_id = JobIDFromString(task_desc_ptr->task_descriptor().job_id());
     JobDescriptor* jd_ptr = FindOrNull(*job_map_, job_id);
     if (jd_ptr == NULL) {
@@ -569,6 +581,7 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
     if (*num_incomplete_tasks == 0) {
       scheduler_->AddJob(jd_ptr);
     }
+    AddTaskToLabelsMap(task_desc_ptr->task_descriptor());
     (*num_incomplete_tasks)++;
     uint64_t* num_tasks_to_remove =
         FindOrNull(job_num_tasks_to_remove_, job_id);

--- a/src/scheduling/firmament_scheduler_service.cc
+++ b/src/scheduling/firmament_scheduler_service.cc
@@ -574,6 +574,7 @@ class FirmamentSchedulerServiceImpl final : public FirmamentScheduler::Service {
       td_ptr->CopyFrom(task_desc_ptr->task_descriptor());
       CHECK(InsertIfNotPresent(task_map_.get(), td_ptr->uid(), td_ptr));
       td_ptr->set_submit_time(wall_time_.GetCurrentTimestamp());
+      scheduler_->UpdateSpawnedToRootTaskMap(td_ptr);
     }
     uint64_t* num_incomplete_tasks =
         FindOrNull(job_num_incomplete_tasks_, job_id);

--- a/src/scheduling/flow/cost_model_interface.h
+++ b/src/scheduling/flow/cost_model_interface.h
@@ -172,6 +172,12 @@ class CostModelInterface {
   virtual void RemoveTaskFromTaskSymmetryMap(TaskDescriptor* td_ptr) {}
 
   /**
+   * Update namespaces entry in resource namespaces map.
+   */
+  virtual void UpdateResourceToNamespacesMap(ResourceID_t res_id,
+                                             string task_namespace, bool add) {}
+
+  /**
    * Removes EC from EC to pod symmetry map.
    */
   virtual void RemoveECFromPodSymmetryMap(EquivClass_t ec) {}

--- a/src/scheduling/flow/cpu_cost_model.h
+++ b/src/scheduling/flow/cpu_cost_model.h
@@ -119,13 +119,17 @@ class CpuCostModel : public CostModelInterface {
   vector<ResourceID_t>* GetTaskPreferenceArcs(TaskID_t task_id);
   // Pod anti-affinity
   bool MatchExpressionWithPodLabels(const ResourceDescriptor& rd,
-                                    const LabelSelectorRequirement& expression);
+                                    const LabelSelectorRequirement& expression,
+                                    bool pod_antiaffinity);
   bool NotMatchExpressionWithPodLabels(
-      const ResourceDescriptor& rd, const LabelSelectorRequirement& expression);
+      const ResourceDescriptor& rd, const LabelSelectorRequirement& expression,
+      bool pod_antiaffinity);
   bool MatchExpressionKeyWithPodLabels(
-      const ResourceDescriptor& rd, const LabelSelectorRequirement& expression);
+      const ResourceDescriptor& rd, const LabelSelectorRequirement& expression,
+      bool pod_antiaffinity);
   bool NotMatchExpressionKeyWithPodLabels(
-      const ResourceDescriptor& rd, const LabelSelectorRequirement& expression);
+      const ResourceDescriptor& rd, const LabelSelectorRequirement& expression,
+      bool pod_antiaffinity);
   bool SatisfiesPodAntiAffinityMatchExpression(
       const ResourceDescriptor& rd,
       const LabelSelectorRequirementAntiAff& expression);

--- a/src/scheduling/flow/cpu_cost_model.h
+++ b/src/scheduling/flow/cpu_cost_model.h
@@ -119,17 +119,13 @@ class CpuCostModel : public CostModelInterface {
   vector<ResourceID_t>* GetTaskPreferenceArcs(TaskID_t task_id);
   // Pod anti-affinity
   bool MatchExpressionWithPodLabels(const ResourceDescriptor& rd,
-                                    const LabelSelectorRequirement& expression,
-                                    bool pod_antiaffinity);
+                                    const LabelSelectorRequirement& expression);
   bool NotMatchExpressionWithPodLabels(
-      const ResourceDescriptor& rd, const LabelSelectorRequirement& expression,
-      bool pod_antiaffinity);
+      const ResourceDescriptor& rd, const LabelSelectorRequirement& expression);
   bool MatchExpressionKeyWithPodLabels(
-      const ResourceDescriptor& rd, const LabelSelectorRequirement& expression,
-      bool pod_antiaffinity);
+      const ResourceDescriptor& rd, const LabelSelectorRequirement& expression);
   bool NotMatchExpressionKeyWithPodLabels(
-      const ResourceDescriptor& rd, const LabelSelectorRequirement& expression,
-      bool pod_antiaffinity);
+      const ResourceDescriptor& rd, const LabelSelectorRequirement& expression);
   bool SatisfiesPodAntiAffinityMatchExpression(
       const ResourceDescriptor& rd,
       const LabelSelectorRequirementAntiAff& expression);
@@ -171,6 +167,8 @@ class CpuCostModel : public CostModelInterface {
   bool CheckPodAffinityAntiAffinitySymmetryConflict(TaskDescriptor* td_ptr);
   void UpdateResourceToTaskSymmetryMap(ResourceID_t res_id, TaskID_t td);
   void RemoveTaskFromTaskSymmetryMap(TaskDescriptor* td_ptr);
+  void UpdateResourceToNamespacesMap(ResourceID_t res_id,
+                                     string task_namespace, bool add);
   void RemoveECFromPodSymmetryMap(EquivClass_t ec);
   bool SatisfiesSymmetryMatchExpression(
       unordered_multimap<string, string> task_labels,
@@ -245,13 +243,6 @@ class CpuCostModel : public CostModelInterface {
     CHECK_NOTNULL(td);
     return *td;
   }
-  inline bool HasNamespace(const string name) {
-    if (namespaces.find(name) == namespaces.end()) {
-      return false;
-    } else {
-      return true;
-    }
-  }
 
   shared_ptr<ResourceMap_t> resource_map_;
   // The task map used in the rest of the system
@@ -277,9 +268,11 @@ class CpuCostModel : public CostModelInterface {
   unordered_map<EquivClass_t, MinMaxScores_t> ec_to_max_min_priority_scores;
   // Pod affinity/anti-affinity
   unordered_map<string, unordered_map<string, vector<TaskID_t>>>* labels_map_;
-  unordered_set<string> namespaces;
+  unordered_map<ResourceID_t, vector<string>, boost::hash<ResourceID_t>>
+                                                      resource_to_namespaces_;
   // Pod affinity/anti-affinity symmetry
-  unordered_map<ResourceID_t, vector<TaskID_t>, boost::hash<ResourceID_t>> resource_to_task_symmetry_map_;
+  unordered_map<ResourceID_t, vector<TaskID_t>, boost::hash<ResourceID_t>> 
+                                                resource_to_task_symmetry_map_;
   unordered_set<EquivClass_t> ecs_with_pod_antiaffinity_symmetry_;
   unordered_map<EquivClass_t, ResourceID_t> ec_to_best_fit_resource_;
   unordered_map<EquivClass_t, Cost_t> ec_to_min_cost_;

--- a/src/scheduling/flow/flow_scheduler.cc
+++ b/src/scheduling/flow/flow_scheduler.cc
@@ -206,7 +206,7 @@ uint64_t FlowScheduler::ApplySchedulingDeltas(
                                    JobIDFromString(td_ptr->job_id()));
     CHECK_NOTNULL(jd);
     if (jd->is_gang_scheduling_job()) {
-      if (td_ptr->has_affinity()
+      if (!affinity_batch_schedule && td_ptr->has_affinity()
           && (td_ptr->affinity().has_pod_affinity()
           || td_ptr->affinity().has_pod_anti_affinity())) {
         if (queue_based_schedule) {
@@ -354,10 +354,49 @@ void FlowScheduler::HandleTasksFromDeregisteredResource(
   }
 }
 
+void FlowScheduler::RemoveAffinityAntiAffinityJobData(JobID_t job_id) {
+  JobDescriptor* jdp = FindOrNull(*job_map_, job_id);
+  if (jdp) {
+    no_conflict_root_tasks_.erase(jdp->root_task().uid());
+    vector<TaskID_t>* tasks_vec =
+          FindOrNull(no_conflict_tasks_map_, jdp->root_task().uid());
+    if (tasks_vec) {
+      if (tasks_vec->size()) {
+        vector<TaskID_t>::iterator it_first = tasks_vec->begin();
+        TaskID_t key_task = *it_first;
+        tasks_vec->erase(it_first);
+        InsertIfNotPresent(&no_conflict_tasks_map_, key_task, *tasks_vec);
+        no_conflict_task_mapped_.erase(key_task);
+        for (auto t : *tasks_vec) {
+          no_conflict_task_mapped_.erase(t);
+          InsertIfNotPresent(&no_conflict_task_mapped_, t, key_task);
+        }
+      }
+      no_conflict_tasks_map_.erase(jdp->root_task().uid());
+    } else {
+      TaskID_t* key_rtask =
+               FindOrNull(no_conflict_task_mapped_, jdp->root_task().uid());
+      if (key_rtask) {
+        vector<TaskID_t>* t_vec =
+                          FindOrNull(no_conflict_tasks_map_, *key_rtask);
+        if (t_vec) {
+          vector<TaskID_t>::iterator it_vec =
+                 find(t_vec->begin(), t_vec->end(), jdp->root_task().uid());
+          if (it_vec != t_vec->end()) {
+            t_vec->erase(it_vec);
+          }
+        }
+        no_conflict_task_mapped_.erase(jdp->root_task().uid());
+      }
+    }
+  }
+}
+
 void FlowScheduler::HandleJobCompletion(JobID_t job_id) {
   boost::lock_guard<boost::recursive_mutex> lock(scheduling_lock_);
   // Job completed, so remove its nodes
   flow_graph_manager_->JobCompleted(job_id);
+  RemoveAffinityAntiAffinityJobData(job_id);
   // Call into superclass handler
   EventDrivenScheduler::HandleJobCompletion(job_id);
 }
@@ -367,7 +406,8 @@ void FlowScheduler::HandleJobRemoval(JobID_t job_id) {
   flow_graph_manager_->JobRemoved(job_id);
   JobDescriptor* jdp = FindOrNull(*job_map_, job_id);
   if (jdp) {
-      affinity_job_to_deltas_.erase(jdp);
+    affinity_job_to_deltas_.erase(jdp);
+    RemoveAffinityAntiAffinityJobData(job_id);
   }
   // Call into superclass handler
   EventDrivenScheduler::HandleJobRemoval(job_id);
@@ -404,12 +444,6 @@ void FlowScheduler::HandleTaskEviction(TaskDescriptor* td_ptr,
   boost::lock_guard<boost::recursive_mutex> lock(scheduling_lock_);
   flow_graph_manager_->TaskEvicted(td_ptr->uid(),
                                    ResourceIDFromString(rd_ptr->uuid()));
-  vector<TaskID_t>::iterator it =
-                    find(affinity_antiaffinity_tasks_->begin(),
-                    affinity_antiaffinity_tasks_->end(), td_ptr->uid());
-  if (it == affinity_antiaffinity_tasks_->end()) {
-     affinity_antiaffinity_tasks_->push_back(*it);
-  }
   if (FLAGS_pod_affinity_antiaffinity_symmetry) {
     cost_model_->RemoveTaskFromTaskSymmetryMap(td_ptr);
   }
@@ -536,13 +570,107 @@ uint64_t FlowScheduler::ScheduleAllJobs(SchedulerStats* scheduler_stats) {
   return ScheduleAllJobs(scheduler_stats, NULL);
 }
 
+vector<TaskID_t>* FlowScheduler::ScheduleAllAffinityBatchJobs(
+                                           SchedulerStats* scheduler_stats,
+                                           vector<SchedulingDelta>* deltas) {
+  boost::lock_guard<boost::recursive_mutex> lock(scheduling_lock_);
+  uint64_t num_scheduled_tasks = 0;
+  vector<TaskID_t>* unscheduled_tasks = new vector<TaskID_t>();
+  affinity_batch_schedule = true;
+  UpdateBatchAffinityTasksMap();
+  for (auto it = no_conflict_tasks_map_.begin();
+       it != no_conflict_tasks_map_.end(); it++) {
+    affinity_batch_job_schedule_.insert(it->first);
+    for (auto rtask : it->second) {
+      affinity_batch_job_schedule_.insert(rtask);
+    }
+    num_scheduled_tasks += ScheduleAllJobs(scheduler_stats, deltas);
+    for (auto rtask : affinity_batch_job_schedule_) {
+      TaskDescriptor* rtd_ptr = FindPtrOrNull(*task_map_, rtask);
+      if (!rtd_ptr) {
+        continue;
+      }
+      JobID_t tdp_job_id = JobIDFromString(rtd_ptr->job_id());
+      if (rtd_ptr->state() == TaskDescriptor::RUNNABLE) {
+        rtd_ptr->set_state(TaskDescriptor::CREATED);
+        runnable_tasks_[tdp_job_id].erase(rtd_ptr->uid());
+        flow_graph_manager_->TaskRemoved(rtd_ptr->uid());
+        unscheduled_tasks->push_back(rtd_ptr->uid());
+      }
+      for (auto td : rtd_ptr->spawned()) {
+        if (td.state() == TaskDescriptor::RUNNABLE) {
+          td.set_state(TaskDescriptor::CREATED);
+          runnable_tasks_[tdp_job_id].erase(td.uid());
+          flow_graph_manager_->TaskRemoved(td.uid());
+          unscheduled_tasks->push_back(td.uid());
+        }
+      }
+    }
+    affinity_batch_job_schedule_.clear();
+  }
+  affinity_batch_schedule = false;
+  return unscheduled_tasks;
+}
+
 uint64_t FlowScheduler::ScheduleAllQueueJobs(SchedulerStats* scheduler_stats,
                                              vector<SchedulingDelta>* deltas) {
   boost::lock_guard<boost::recursive_mutex> lock(scheduling_lock_);
   queue_based_schedule = true;
+  auto task_itr = affinity_antiaffinity_tasks_->begin();
+  TaskDescriptor* tdp = FindPtrOrNull(*task_map_, *task_itr);
+  if (tdp) {
+    if (tdp->state() == TaskDescriptor::RUNNABLE) {
+      TaskID_t task_id = *task_itr;
+      tdp->set_state(TaskDescriptor::CREATED);
+      affinity_antiaffinity_tasks_->erase(task_itr);
+      affinity_antiaffinity_tasks_->push_back(task_id);
+      JobID_t tdp_job_id = JobIDFromString(tdp->job_id());
+      runnable_tasks_[tdp_job_id].erase(task_id);
+      flow_graph_manager_->TaskRemoved(task_id);
+    }
+  }
   uint64_t num_scheduled_tasks = ScheduleAllJobs(scheduler_stats, deltas);
   queue_based_schedule = false;
   return num_scheduled_tasks;
+}
+
+void FlowScheduler::UpdateBatchAffinityTasksMap() {
+  for (auto task : no_conflict_root_tasks_) {
+    bool matched = false;
+    TaskDescriptor* rtd = FindPtrOrNull(*task_map_, task);
+    for (auto it = no_conflict_tasks_map_.begin();
+              it != no_conflict_tasks_map_.end(); it++) {
+      TaskDescriptor* other_rtd = FindPtrOrNull(*task_map_, it->first);
+      if (!CheckPodAffinityNoConflictWithin(rtd, other_rtd)
+          || !CheckPodAntiAffinityNoConflictWithin(rtd, other_rtd)
+          || !CheckPodAffinityNoConflictWithin(other_rtd, rtd)
+          || !CheckPodAntiAffinityNoConflictWithin(other_rtd, rtd)) {
+        continue;
+      }
+      bool other_task_match = true;
+      for (auto other_task : it->second) {
+        other_rtd = FindPtrOrNull(*task_map_, other_task);
+        if (!CheckPodAffinityNoConflictWithin(rtd, other_rtd)
+            || !CheckPodAntiAffinityNoConflictWithin(rtd, other_rtd)
+            || !CheckPodAffinityNoConflictWithin(other_rtd, rtd)
+            || !CheckPodAntiAffinityNoConflictWithin(other_rtd, rtd)) {
+          other_task_match = false;
+          break;
+        }
+      }
+      if (!other_task_match) {
+        continue;
+      } else {
+        matched = true;
+        it->second.push_back(task);
+        InsertIfNotPresent(&no_conflict_task_mapped_, task, it->first);
+      }
+    }
+    if (!matched) {
+      vector<TaskID_t> tasks_vec;
+      InsertIfNotPresent(&no_conflict_tasks_map_, task, tasks_vec);
+    }
+  }
 }
 
 uint64_t FlowScheduler::ScheduleAllJobs(SchedulerStats* scheduler_stats,
@@ -551,11 +679,21 @@ uint64_t FlowScheduler::ScheduleAllJobs(SchedulerStats* scheduler_stats,
   vector<JobDescriptor*> jobs;
   //Pod affinity/anti-affinity
   one_task_runnable = false;
+  if (affinity_batch_schedule) {
+    if (!affinity_batch_job_schedule_.size()) {
+      return 0;
+    }
+  }
   for (auto& job_id_jd : jobs_to_schedule_) {
     const TaskDescriptor& td = job_id_jd.second->root_task();
     if (queue_based_schedule) {
       if (!(td.has_affinity() && (td.affinity().has_pod_affinity() ||
           td.affinity().has_pod_anti_affinity()))) {
+        continue;
+      }
+    } else if (affinity_batch_schedule) {
+      if (affinity_batch_job_schedule_.find(td.uid())
+                            == affinity_batch_job_schedule_.end()) {
         continue;
       }
     } else {
@@ -898,27 +1036,27 @@ void FlowScheduler::AddKnowledgeBaseResourceStats(TaskDescriptor* td_ptr,
 void FlowScheduler::UpdateGangSchedulingDeltas(
                     SchedulerStats* scheduler_stats,
                     vector<SchedulingDelta>* deltas_output,
-                    vector<uint64_t>* unscheduled_normal_tasks,
+                    vector<uint64_t>* unscheduled_batch_tasks,
                     unordered_set<uint64_t>* unscheduled_affinity_tasks_set,
                     vector<uint64_t>* unscheduled_affinity_tasks) {
   // update batch schedule deltas
   for (auto job_ptr : delta_jobs) {
     TaskDescriptor rtd = job_ptr->root_task();
     for (auto td : rtd.spawned()) {
-      vector<uint64_t>::iterator it = find(unscheduled_normal_tasks->begin(),
-                                      unscheduled_normal_tasks->end(),
+      vector<uint64_t>::iterator it = find(unscheduled_batch_tasks->begin(),
+                                      unscheduled_batch_tasks->end(),
                                       td.uid());
-      if (it == unscheduled_normal_tasks->end()) {
-        unscheduled_normal_tasks->push_back(td.uid());
+      if (it == unscheduled_batch_tasks->end()) {
+        unscheduled_batch_tasks->push_back(td.uid());
       }
     }
     delta_jobs.clear();
 
-    vector<uint64_t>::iterator rit = find(unscheduled_normal_tasks->begin(),
-                                     unscheduled_normal_tasks->end(),
+    vector<uint64_t>::iterator rit = find(unscheduled_batch_tasks->begin(),
+                                     unscheduled_batch_tasks->end(),
                                      rtd.uid());
-    if (rit == unscheduled_normal_tasks->end()) {
-      unscheduled_normal_tasks->push_back(rtd.uid());
+    if (rit == unscheduled_batch_tasks->end()) {
+      unscheduled_batch_tasks->push_back(rtd.uid());
     }
   }
 
@@ -927,7 +1065,7 @@ void FlowScheduler::UpdateGangSchedulingDeltas(
             it != affinity_job_to_deltas_.end(); ++it) {
     JobDescriptor* jd_ptr = it->first;
     TaskDescriptor root_td = jd_ptr->root_task();
-    if (!it->second.size()) {
+    if (!it->second.size() && !jd_ptr->min_number_of_tasks()) {
       for (auto td : root_td.spawned()) {
         if (td.state() != TaskDescriptor::RUNNING) {
           unscheduled_affinity_tasks_set->insert(td.uid());
@@ -953,6 +1091,15 @@ void FlowScheduler::UpdateGangSchedulingDeltas(
         HandleTaskEviction(td_ptr, rs->mutable_descriptor());
         td_ptr->set_state(TaskDescriptor::CREATED);
         td_ptr->clear_scheduled_to_resource();
+        if (no_conflict_root_tasks_.find(root_td.uid())
+                                    == no_conflict_root_tasks_.end()) {
+          vector<TaskID_t>::iterator it =
+                          find(affinity_antiaffinity_tasks_->begin(),
+                          affinity_antiaffinity_tasks_->end(), td_ptr->uid());
+          if (it == affinity_antiaffinity_tasks_->end()) {
+            affinity_antiaffinity_tasks_->push_back(td_ptr->uid());
+          }
+        }
         JobID_t job_id = JobIDFromString(jd_ptr->uuid());
         unordered_set<TaskID_t>* runnables_for_job =
           FindOrNull(runnable_tasks_, job_id);

--- a/src/scheduling/flow/flow_scheduler.h
+++ b/src/scheduling/flow/flow_scheduler.h
@@ -102,6 +102,7 @@ class FlowScheduler : public EventDrivenScheduler {
                      vector<uint64_t>* unscheduled_normal_tasks,
                      unordered_set<uint64_t>* unscheduled_affinity_tasks_set,
                      vector<uint64_t>* unscheduled_affinity_tasks);
+  virtual void UpdateSpawnedToRootTaskMap(TaskDescriptor* td_ptr);
   virtual uint64_t ScheduleAllJobs(SchedulerStats* scheduler_stats,
                                    vector<SchedulingDelta>* deltas);
   virtual uint64_t ScheduleJob(JobDescriptor* jd_ptr,
@@ -150,6 +151,7 @@ class FlowScheduler : public EventDrivenScheduler {
                                                  ResourceStatus* rs);
   void UpdateBatchAffinityTasksMap();
   void RemoveAffinityAntiAffinityJobData(JobID_t job_id);
+  bool CheckAllTasksInJobRunning(TaskDescriptor* rtd);
 
   // Pointer to the coordinator's topology manager
   shared_ptr<TopologyManager> topology_manager_;

--- a/src/scheduling/flow/flow_scheduler.h
+++ b/src/scheduling/flow/flow_scheduler.h
@@ -91,6 +91,9 @@ class FlowScheduler : public EventDrivenScheduler {
                                 bool local,
                                 bool simulated);
   virtual uint64_t ScheduleAllJobs(SchedulerStats* scheduler_stats);
+  virtual vector<TaskID_t>* ScheduleAllAffinityBatchJobs(
+                                      SchedulerStats* scheduler_stats,
+                                      vector<SchedulingDelta>* deltas);
   virtual uint64_t ScheduleAllQueueJobs(SchedulerStats* scheduler_stats,
                                         vector<SchedulingDelta>* deltas);
   virtual void UpdateGangSchedulingDeltas(
@@ -122,7 +125,9 @@ class FlowScheduler : public EventDrivenScheduler {
   }
 
   TaskID_t GetSingleTaskTobeScheduled() {
-    return task_to_be_scheduled_;
+    TaskID_t task_id = task_to_be_scheduled_;
+    task_to_be_scheduled_ = 0;
+    return task_id;
   }
  protected:
   virtual void HandleTaskMigration(TaskDescriptor* td_ptr,
@@ -143,6 +148,8 @@ class FlowScheduler : public EventDrivenScheduler {
   void UpdateCostModelResourceStats();
   void AddKnowledgeBaseResourceStats(TaskDescriptor* td_ptr,
                                                  ResourceStatus* rs);
+  void UpdateBatchAffinityTasksMap();
+  void RemoveAffinityAntiAffinityJobData(JobID_t job_id);
 
   // Pointer to the coordinator's topology manager
   shared_ptr<TopologyManager> topology_manager_;
@@ -170,6 +177,7 @@ class FlowScheduler : public EventDrivenScheduler {
   unordered_set<ResourceTopologyNodeDescriptor*> resource_roots_;
   // Single task that needs to scheduled in queue based scheduling round.
   TaskID_t task_to_be_scheduled_;
+  unordered_set<TaskID_t> affinity_batch_job_schedule_;
 };
 
 }  // namespace scheduler

--- a/src/scheduling/scheduler_interface.h
+++ b/src/scheduling/scheduler_interface.h
@@ -247,6 +247,17 @@ class SchedulerInterface : public PrintableInterface {
   virtual uint64_t ScheduleAllJobs(SchedulerStats* scheduler_stats) = 0;
   virtual uint64_t ScheduleAllJobs(SchedulerStats* scheduler_stats,
                                    vector<SchedulingDelta>* deltas) = 0;
+
+  /**
+   * Runs a scheduling iteration for all active queue based jobs.
+   * @return the number of tasks scheduled
+   */
+  virtual vector<TaskID_t>* ScheduleAllAffinityBatchJobs(
+                                      SchedulerStats* scheduler_stats,
+                                      vector<SchedulingDelta>* deltas) {
+    return NULL;
+  }
+
   /**
    * Runs a scheduling iteration for all active queue based jobs.
    * @return the number of tasks scheduled
@@ -286,6 +297,14 @@ class SchedulerInterface : public PrintableInterface {
                                 SchedulerStats* scheduler_stats,
                                 vector<SchedulingDelta>* deltas = NULL) = 0;
 
+  /**
+   * Return the lists of root task of each job that do not
+   * have conflict within tasks of that job.
+   */
+  virtual unordered_set<TaskID_t>* GetNoConflictTasksSet() {
+    return NULL;
+  }
+
  protected:
   /**
    * Handles the migration of a task.
@@ -313,6 +332,7 @@ class SchedulerInterface : public PrintableInterface {
    */
   virtual const unordered_set<TaskID_t>& ComputeRunnableTasksForJob(
       JobDescriptor* jd_ptr) = 0;
+
 
   // Pointers to the associated coordinator's job, resource and object maps
   shared_ptr<JobMap_t> job_map_;

--- a/src/scheduling/scheduler_interface.h
+++ b/src/scheduling/scheduler_interface.h
@@ -305,6 +305,11 @@ class SchedulerInterface : public PrintableInterface {
     return NULL;
   }
 
+  /**
+   * Updates with a entry in
+   */
+  virtual void UpdateSpawnedToRootTaskMap(TaskDescriptor* td_ptr) {}
+
  protected:
   /**
    * Handles the migration of a task.


### PR DESCRIPTION
This PR improves the pod ```Affinity/Anti-affinity``` performance.
Currently we process pod by pod for all pods having pod affinity/anti-affinity. With this change we group pods that can be processed together and separate other pods that need to be processed one by one. This is done before scheduling by analysing the ```Affinity/Anti-affinity``` conflicts among pods and grouping into sets of pods that can be processed together. The pod that do not have conflict with other pods can be processed in batch with those pods and the pods that have conflict with all other pods shall be processed one by one. So lesser the affinity/anti-affinity conflicts among pending pods better is the performance of scheduling.